### PR TITLE
Loki 2.0: Matrix for Clickhouse

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,16 @@ The *Loki API* and its Grafana native integration are brilliant, simple and appe
 
 <img src="https://user-images.githubusercontent.com/1423657/54091852-5ce91000-4385-11e9-849d-998c1e5d3243.png" width=700 />
 
-*The current purpose of this project is to research and understand inner aspects of the original implementation.*
+#### Experimental Features
+
+cLoki implements custom query functions for clickhouse, allowing direct access to any data regardless of the Loki tables.
+
+##### Matrix
+Convert columns to tagged timeseries using the experimental `clickhouse` function
+```
+clickhouse({db="my_database", table="my_table", tag="source_ip", metric="avg(mos)", interval=60})
+```
+<img src="https://user-images.githubusercontent.com/1423657/99422089-6dde7880-28ff-11eb-8254-7f0add8860cd.png" />
 
 ------------
 ### Setup

--- a/README.md
+++ b/README.md
@@ -35,6 +35,13 @@ npm start
 ##### :busstop: Docker
 For a fully working demo, check the [docker-compose](https://github.com/lmangani/cLoki/tree/master/docker) example
 
+##### Manually
+```
+CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_DB="my_data" CLICKHOUSE_AUTH="default:password" DEBUG=true node cloki.js
+```
+
+--------------
+
 #### Configuration
 The following ENV Variables can be used to control cLoki parameters and backend settings.
 

--- a/cloki.js
+++ b/cloki.js
@@ -168,7 +168,7 @@ fastify.get('/loki/api/v1/query_range', (req, res) => {
   var params = req.query;
   var resp = { "streams": [] };
   if (!req.query.query) { res.send(resp); return; }
-  if (req.query.query.startsWith("clickhouse("){
+  if (req.query.query.startsWith("clickhouse(")){
 
      try {
 	  var query = /\{(.*?)\}/g.exec(req.query.query)[1] || req.query.query;

--- a/cloki.js
+++ b/cloki.js
@@ -175,7 +175,7 @@ fastify.get('/loki/api/v1/query_range', (req, res) => {
 	  var queries = query.replace(/\!?=/g,':');
 	  var JSON_labels = toJSON(queries);
      } catch(e){ console.error(e, queries); res.send(resp); }
-     if (debug) console.log('SCAN CLICKHOUSE',JSON_labels,label_rules,params)
+     if (debug) console.log('SCAN CLICKHOUSE',JSON_labels,params)
      scanClickhouse(JSON_labels,res,params);
   } else {
      try {

--- a/cloki.js
+++ b/cloki.js
@@ -33,6 +33,7 @@ var labelParser = UTILS.labelParser;
 var init = DATABASE.init;
 var reloadFingerprints = DATABASE.reloadFingerprints;
 var scanFingerprints = DATABASE.scanFingerprints;
+var scanClickhouse = DATABASE.scanClickhouse;
 
 init(process.env.CLICKHOUSE_TSDB || 'loki');
 
@@ -166,18 +167,29 @@ fastify.get('/loki/api/v1/query_range', (req, res) => {
   // console.log( req.urlData().query.replace('query=',' ') );
   var params = req.query;
   var resp = { "streams": [] };
-  if (!req.query.query) { res.send(resp);return; }
-  try {
+  if (!req.query.query) { res.send(resp); return; }
+  if (req.query.query.startsWith("clickhouse("){
 
+     try {
+	  var query = /\{(.*?)\}/g.exec(req.query.query)[1] || req.query.query;
+	  var queries = query.replace(/\!?=/g,':');
+	  var JSON_labels = toJSON(queries);
+     } catch(e){ console.error(e, queries); res.send(resp); }
+     if (debug) console.log('SCAN CLICKHOUSE',JSON_labels,label_rules,params)
+     scanClickhouse(JSON_labels,res,params);
+  } else {
+     try {
 	  var label_parser = labelParser(req.query.query);
 	  var label_rules = label_parser.labels;
 	  var label_regex = label_parser.regex;
 	  var query = /\{(.*?)\}/g.exec(req.query.query)[1] || req.query.query;
 	  var queries = query.replace(/\!?=/g,':');
 	  var JSON_labels = toJSON(queries);
-  } catch(e){ console.error(e, queries); res.send(resp); }
-  if (debug) console.log('SCAN LABELS',JSON_labels,label_rules,params)
-  scanFingerprints(JSON_labels,res,params,label_rules,label_regex);
+     } catch(e){ console.error(e, queries); res.send(resp); }
+     if (debug) console.log('SCAN LABELS',JSON_labels,label_rules,params)
+     scanFingerprints(JSON_labels,res,params,label_rules,label_regex);
+
+  }
 
 });
 

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -255,10 +255,79 @@ var scanFingerprints = function(JSON_labels,client,params,label_rules,label_rege
 		  }
 		  results.stream = JSON_labels;
 		  results.stream.source = "JSON";
-
 	  	  client.send(resp);
 
 		});
+	});
+}
+
+/* Clickhouse Metrics Column Query */
+var scanClickhouse = function(settings,client,params){
+	if (debug) console.log('Scanning Clickhouse...',settings);
+
+	// populate matrix structure
+	var results =
+	         {
+	            "metric":{},
+	            "values": []
+	         };
+
+	var resp = {
+	   "status":"success",
+	   "data":{
+	      "resultType":"matrix",
+	      "result":[results]
+	   }
+	}
+
+	// Check for required fields or return nothing!
+	if(!settings||!settings.table||!settings.db||!settings.tag||!settings.value) { client.send(resp); return; }
+	if (!settings.interval) settings.interval = 60;
+	if (!settings.timefield) settings.timefield = "record_datetime";
+
+	// Lets query!
+	var template = 	"SELECT "+settings.tag+", groupArray((t, c)) AS groupArr FROM ("
+		     		+ "SELECT (intDiv(toUInt32("+settings.timefield+"), "+settings.interval+") * "+settings.intervel+") * 1000 AS t, "+settings.tag+", "+settings.value+" c "
+				+ "FROM "+settings.db+"."+settings.table;
+				if (params.start && params.end) {
+				template += " AND "+settings.timefield+" BETWEEN "+parseInt(params.start/1000000) +" AND "+parseInt(params.end/1000000)
+				}
+				template += "GROUP BY t, "+settings.tag+" ORDER BY t, "+settings.tag+")";
+	template += 	"GROUP BY "+settings.tag+" ORDER BY "+settings.tag
+	if (debug) console.log('SEARCH QUERY',template)
+
+  	var stream = ch.query(template);
+  	// or collect records yourself
+	var rows = [];
+		stream.on ('metadata', function (columns) {
+	  // do something with column list
+	});
+	stream.on ('data', function (row) {
+	  rows.push (row);
+	});
+	stream.on ('error', function (err) {
+	  // TODO: handler error
+	  resp.status = "failed";
+	  resp.data.result = [];
+	  resp.data.message = err;
+	  client.send(resp);
+	});
+	stream.on ('end', function () {
+	  if (debug) console.log('RESPONSE:',rows);
+	  if (!rows||rows.length < 1) {
+		resp.data.result =[];
+		resp.data.stats = fakeStats;
+	  } else {
+		rows.forEach(function(row){
+		    var metrics = { metric: {}, values: []);
+		    metric.metric[settings.tag] = row[0];
+		    row[1].forEach(function(row){
+			metrics.values.push( [ parseInt(row[0] * 1000000), row[1] ]);
+	  	    });
+		    resp.data.result.push(metric);
+	  	});
+	  }
+  	  client.send(resp);
 	});
 }
 
@@ -269,5 +338,6 @@ module.exports.database_options = clickhouse_options;
 module.exports.database = clickhouse;
 module.exports.cache = { bulk: bulk, bulk_labels: bulk_labels, labels: labels };
 module.exports.scanFingerprints = scanFingerprints;
+module.exports.scanClickhouse = scanClickhouse;
 module.exports.reloadFingerprints = reloadFingerprints;
 module.exports.init = initialize;

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -319,7 +319,7 @@ var scanClickhouse = function(settings,client,params){
 		resp.data.stats = fakeStats;
 	  } else {
 		rows.forEach(function(row){
-		    var metrics = { metric: {}, values: []);
+		    var metrics = { metric: {}, values: [] };
 		    metric.metric[settings.tag] = row[0];
 		    row[1].forEach(function(row){
 			metrics.values.push( [ parseInt(row[0] * 1000000), row[1] ]);

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -281,20 +281,20 @@ var scanClickhouse = function(settings,client,params){
 	}
 
 	// Check for required fields or return nothing!
-	if(!settings||!settings.table||!settings.db||!settings.tag||!settings.value) { client.send(resp); return; }
+	if(!settings||!settings.table||!settings.db||!settings.tag||!settings.metric) { client.send(resp); return; }
 	if (!settings.interval) settings.interval = 60;
 	if (!settings.timefield) settings.timefield = "record_datetime";
 
 	// Lets query!
 	var template = 	"SELECT "+settings.tag+", groupArray((t, c)) AS groupArr FROM ("
-		     		+ "SELECT (intDiv(toUInt32("+settings.timefield+"), "+settings.interval+") * "+settings.intervel+") * 1000 AS t, "+settings.tag+", "+settings.value+" c "
+		     		+ "SELECT (intDiv(toUInt32("+settings.timefield+"), "+settings.interval+") * "+settings.interval+") * 1000 AS t, "+settings.tag+", "+settings.metric+" c "
 				+ "FROM "+settings.db+"."+settings.table;
 				if (params.start && params.end) {
-				template += " AND "+settings.timefield+" BETWEEN "+parseInt(params.start/1000000) +" AND "+parseInt(params.end/1000000)
+				template += " PREWHERE "+settings.timefield+" BETWEEN "+parseInt(params.start/1000000000) +" AND "+parseInt(params.end/1000000000)
 				}
-				template += "GROUP BY t, "+settings.tag+" ORDER BY t, "+settings.tag+")";
-	template += 	"GROUP BY "+settings.tag+" ORDER BY "+settings.tag
-	if (debug) console.log('SEARCH QUERY',template)
+				template += " GROUP BY t, "+settings.tag+" ORDER BY t, "+settings.tag+")";
+	template += 	" GROUP BY "+settings.tag+" ORDER BY "+settings.tag
+	if (debug) console.log('CLICKHOUSE SEARCH QUERY',template)
 
   	var stream = ch.query(template);
   	// or collect records yourself
@@ -313,20 +313,22 @@ var scanClickhouse = function(settings,client,params){
 	  client.send(resp);
 	});
 	stream.on ('end', function () {
-	  if (debug) console.log('RESPONSE:',rows);
+	  if (debug) console.log('CLICKHOUSE RESPONSE:',rows);
 	  if (!rows||rows.length < 1) {
 		resp.data.result =[];
 		resp.data.stats = fakeStats;
 	  } else {
 		rows.forEach(function(row){
 		    var metrics = { metric: {}, values: [] };
-		    metric.metric[settings.tag] = row[0];
+		    metrics.metric[settings.tag] = row[0];
 		    row[1].forEach(function(row){
-			metrics.values.push( [ parseInt(row[0] * 1000000), row[1] ]);
+			// if (row[1] == 0) return;
+			metrics.values.push( [ parseInt(row[0]/1000), row[1].toString() ]);
 	  	    });
-		    resp.data.result.push(metric);
+		    resp.data.result.push(metrics);
 	  	});
 	  }
+	  if (debug) console.log('CLOKI RESPONSE',JSON.stringify(resp));
   	  client.send(resp);
 	});
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,7 +22,8 @@ const toJSON = require('jsonic');
 
 /* clickhouse query parser */
 var clickParser = function(query){
-   // clickhouse({db="mydb", table="mytable", tag="key", metric="value", interval=60})
+   /* Example cQL format */
+   /* clickhouse({db="mydb", table="mytable", tag="key", metric="avg(value)", interval=60}) */
    var regx = /clickhouse\((.*)\)/g
    var clickQuery = regx.exec(req.query.query)[1] || false;
    return labelParser(clickQuery);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -20,6 +20,15 @@ var fingerPrint = function(text,hex){
 
 const toJSON = require('jsonic');
 
+/* clickhouse query parser */
+var clickParser = function(query){
+   // clickhouse({db="mydb", table="mytable", tag="key", metric="value", interval=60})
+   var regx = /clickhouse\((.*)\)/g
+   var clickQuery = regx.exec(req.query.query)[1] || false;
+   return labelParser(clickQuery);
+}
+
 module.exports.fingerPrint = fingerPrint;
 module.exports.labelParser = labelParser;
+module.exports.clickParser = clickParser;
 module.exports.toJSON = toJSON;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cloki",
-  "version": "1.0.14",
+  "version": "1.0.20",
   "description": "Loki API with Clickhouse Backend",
   "main": "cloki.js",
   "scripts": {


### PR DESCRIPTION
This PR rides on the Loki 2.0 features by implementing our own clickhouse function to get metrics out of tables.
See #19 for details!

The query format is currently a pure experiment, but will be designed to remain native to clickhouse:
```
clickhouse({db="my_database", table="my_table", tag="source_ip", metric="avg(mos)"})
```

![image](https://user-images.githubusercontent.com/1423657/99422089-6dde7880-28ff-11eb-8254-7f0add8860cd.png)
