### PR TITLE
Allow | separators in tags for CliQL

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -572,7 +572,8 @@ const scanClickhouse = function (settings, client, params) {
   if (!settings || !settings.table || !settings.db || !settings.tag || !settings.metric) { client.send(resp); return }
   settings.interval = settings.interval ? parseInt(settings.interval) : 60
   if (!settings.timefield) settings.timefield = process.env.TIMEFIELD || 'record_datetime'
-
+  if (settings.tag.includes('|')) { settings.tag = settings.tag.split("|").join(",") }
+  
   // Lets query!
   let template = 'SELECT ' + settings.tag + ', groupArray((t, c)) AS groupArr FROM (' +
     'SELECT (intDiv(toUInt32(' + settings.timefield + '), ' + settings.interval + ') * ' + settings.interval + ') * 1000 AS t, ' + settings.tag + ', ' + settings.metric + ' c ' +


### PR DESCRIPTION
Minor patch restricted to the CliQL parser (not logs) to support multiselect variable groups separated by `|` in Grafana

> $groups = Grafana multiselect (a, b, c)
> avg by (${group}) (rate(mos/100[60])) from hepic_data.sip_transaction_call WHERE mos > 0

results in 

> avg by (a|b|c) (rate(mos/100[60])) from hepic_data.sip_transaction_call WHERE mos > 0

Expected impact = none

