### PR TITLE
allow bypassing timefield

### DIFF
--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -685,20 +685,32 @@ const scanClickhouse = function (settings, client, params) {
     }
   }
 
+  // TODO: Replace this template with a proper parser!
   // Check for required fields or return nothing!
   if (!settings || !settings.table || !settings.db || !settings.tag || !settings.metric) { client.send(resp); return }
   settings.interval = settings.interval ? parseInt(settings.interval) : 60
+  // Normalize timefield
   if (!settings.timefield) settings.timefield = process.env.TIMEFIELD || 'record_datetime'
+  else if (settings.timefield == "false") settings.timefield = false;
+  // Normalize Tags
   if (settings.tag.includes('|')) { settings.tag = settings.tag.split('|').join(',') }
   // Lets query!
-  let template = 'SELECT ' + settings.tag + ', groupArray((t, c)) AS groupArr FROM (' +
-    'SELECT (intDiv(toUInt32(' + settings.timefield + '), ' + settings.interval + ') * ' + settings.interval + ') * 1000 AS t, ' + settings.tag + ', ' + settings.metric + ' c ' +
-    'FROM ' + settings.db + '.' + settings.table
-  if (params.start && params.end) {
-    template += ' PREWHERE ' + settings.timefield + ' BETWEEN ' + parseInt(params.start / 1000000000) + ' AND ' + parseInt(params.end / 1000000000)
+  let template = 'SELECT ' + settings.tag + ', groupArray((t, c)) AS groupArr FROM (';
+  // Check for timefield or Bypass timefield
+  if (settings.timefield){
+    template += 'SELECT (intDiv(toUInt32(' + settings.timefield + '), ' + settings.interval + ') * ' + settings.interval + ') * 1000 AS t, ' + settings.tag + ', ' + settings.metric + ' c '
+  } else {
+    template += 'SELECT toUnixTimestamp(now()) * 1000 AS t, ' + settings.tag + ', ' + settings.metric + ' c '
   }
-  if (settings.where) {
-    template += ' AND ' + settings.where
+  template +=  'FROM ' + settings.db + '.' + settings.table
+  // Check for timefield or standalone where conditions
+  if (params.start && params.end && settings.timefield) {
+    template += ' PREWHERE ' + settings.timefield + ' BETWEEN ' + parseInt(params.start / 1000000000) + ' AND ' + parseInt(params.end / 1000000000)
+    if (settings.where) {
+      template += ' AND ' + settings.where
+    }
+  } else if (settings.where){
+    template += ' WHERE ' + settings.where
   }
   template += ' GROUP BY t, ' + settings.tag + ' ORDER BY t, ' + settings.tag + ')'
   template += ' GROUP BY ' + settings.tag + ' ORDER BY ' + settings.tag


### PR DESCRIPTION
```
clickhouse({ 
  db="system", 
  table="disks", 
  tag="name", 
  metric="avg((total_space-free_space)/total_space*100)", 
  where="((total_space-free_space)/total_space*100) < 50", 
  timefield="false"
})
```