### PR TITLE
WIP: Prometheus Remote Write API

### DIFF
--- a/cloki.js
+++ b/cloki.js
@@ -23,7 +23,7 @@ const path = require("path");
 const protoBuff = require('protocol-buffers')
 const messages = protoBuff(fs.readFileSync('lib/loki.proto'))
 const protobufjs = require("protobufjs");
-const WriteRequest = protobufjs.loadSync(path.join(__dirname, "trace.proto")).lookupType("WriteRequest");
+const WriteRequest = protobufjs.loadSync(path.join(__dirname, "lib/prompb.proto")).lookupType("WriteRequest");
 
 /* Alerting */
 const { startAlerting, stop } = require('./lib/db/alerting')

--- a/cloki.js
+++ b/cloki.js
@@ -19,6 +19,7 @@ const UTILS = require('./lib/utils')
 
 /* ProtoBuf Helpers */
 const fs = require('fs')
+const path = require("path");
 const protoBuff = require('protocol-buffers')
 const messages = protoBuff(fs.readFileSync('lib/loki.proto'))
 const protobufjs = require("protobufjs");

--- a/cloki.js
+++ b/cloki.js
@@ -17,11 +17,15 @@ require('./plugins/engine')
 const DATABASE = require('./lib/db/clickhouse')
 const UTILS = require('./lib/utils')
 
-/* ProtoBuf Helper */
+/* ProtoBuf Helpers */
 const fs = require('fs')
 const protoBuff = require('protocol-buffers')
-const { startAlerting, stop } = require('./lib/db/alerting')
 const messages = protoBuff(fs.readFileSync('lib/loki.proto'))
+const protobufjs = require("protobufjs");
+const WriteRequest = protobufjs.loadSync(path.join(__dirname, "trace.proto")).lookupType("WriteRequest");
+
+/* Alerting */
+const { startAlerting, stop } = require('./lib/db/alerting')
 const yaml = require('yaml')
 
 /* Fingerprinting */
@@ -52,7 +56,6 @@ this.scanClickhouse = DATABASE.scanClickhouse;
 
 /* Fastify Helper */
 const fastify = require('fastify')({
-
   logger: false,
   bodyLimit: parseInt(process.env.FASTIFY_BODYLIMIT) || 5242880,
   requestTimeout: parseInt(process.env.FASTIFY_REQUESTTIMEOUT) || 0,
@@ -114,19 +117,26 @@ try {
   /* Protobuf Handler */
   fastify.addContentTypeParser('application/x-protobuf', { parseAs: 'buffer' },
     async function (req, body, done) {
-      let _data = await snappy.uncompress(body)
-      _data = messages.PushRequest.decode(_data)
-      _data.streams = _data.streams.map(s => ({
-        ...s,
-        entries: s.entries.map(e => {
-          const millis = Math.floor(e.timestamp.nanos / 1000000)
-          return {
-            ...e,
-            timestamp: e.timestamp.seconds * 1000 + millis
-          }
-        })
-      }))
-      return _data.streams
+      // Prometheus Protobuf Write Handler
+      if (req.url == '/api/v1/prom/remote/write') {
+          let _data = await snappy.uncompress(body)
+          return WriteRequest.decode(snappy.uncompress(_data))
+      // Loki Protobuf Push Handler
+      } else {
+        let _data = await snappy.uncompress(body)
+        _data = messages.PushRequest.decode(_data)
+        _data.streams = _data.streams.map(s => ({
+          ...s,
+          entries: s.entries.map(e => {
+            const millis = Math.floor(e.timestamp.nanos / 1000000)
+            return {
+              ...e,
+              timestamp: e.timestamp.seconds * 1000 + millis
+            }
+          })
+        }))
+        return _data.streams
+      }
     })
 } catch (e) {
   console.log(e)
@@ -194,6 +204,10 @@ fastify.post('/api/prom/rules/:ns', require('./lib/handlers/alerts/post_group').
 fastify.delete('/api/prom/rules/:ns/:group', require('./lib/handlers/alerts/del_group').bind(this))
 fastify.delete('/api/prom/rules/:ns', require('./lib/handlers/alerts/del_ns').bind(this))
 fastify.get('/prometheus/api/v1/rules', require('./lib/handlers/alerts/prom_get_rules').bind(this))
+
+// PROMETHEUS REMOTE WRITE
+fastify.post('/api/v1/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
+fastify.post('/api/prom/remote/write', require('./lib/handlers/prom_push.js').bind(this))
 
 // Run API Service
 fastify.listen(

--- a/cloki.js
+++ b/cloki.js
@@ -121,7 +121,8 @@ try {
       // Prometheus Protobuf Write Handler
       if (req.url == '/api/v1/prom/remote/write') {
           let _data = await snappy.uncompress(body)
-          return WriteRequest.decode(snappy.uncompress(_data))
+          _data = WriteRequest.decode(_data)
+          return _data;
       // Loki Protobuf Push Handler
       } else {
         let _data = await snappy.uncompress(body)

--- a/lib/handlers/prom_push.js
+++ b/lib/handlers/prom_push.js
@@ -1,10 +1,10 @@
 /* Prometheus Remote Write Handler for cLoki */
-/* 
+/*
 
-   Accepts Prometheus WriteRequest Protobuf events 
+   Accepts Prometheus WriteRequest Protobuf events
 
    { "timeseries":[
-      { 
+      {
         "labels":[{"name":"test","response_code":"200"}],
         "samples":[{"value":7.1,"timestamp":"1641758471000"}]
      }]
@@ -26,24 +26,17 @@ function handler (req, res) {
     return
   }
   let streams
-  if (
-    req.headers['content-type'] &&
-                req.headers['content-type'].indexOf('application/json') > -1
-  ) {
-    streams = req.body.timeseries
-  } else if (
-    req.headers['content-type'] &&
-                req.headers['content-type'].indexOf('application/x-protobuf') > -1
-  ) {
+  if (req.headers['content-type'] && req.headers['content-type'].indexOf('application/x-protobuf') > -1) {
     streams = req.body.timeseries
   }
   if (streams) {
     streams.forEach(function (stream) {
+      let JSONLabels
       let finger = null
       try {
-        let JSONLabels
+        // let JSONLabels
         try {
-            JSONLabels = stream.labels[0]
+          JSONLabels = stream.labels[0]
         } catch (e) {
           console.error(e)
           return

--- a/lib/handlers/prom_push.js
+++ b/lib/handlers/prom_push.js
@@ -1,0 +1,96 @@
+/* Prometheus Remote Write Handler for cLoki */
+/* 
+
+   Accepts Prometheus WriteRequest Protobuf events 
+
+   { "timeseries":[
+      { 
+        "labels":[{"name":"test","response_code":"200"}],
+        "samples":[{"value":7.1,"timestamp":"1641758471000"}]
+     }]
+   }
+
+*/
+
+function handler (req, res) {
+  const self = this
+  if (this.debug) console.log('POST /api/v1/prom/remote/write')
+  if (!req.body) {
+    console.error('No Request Body!', req)
+    res.code(500).send()
+    return
+  }
+  if (this.readonly) {
+    console.error('Readonly! No push support.')
+    res.code(500).send()
+    return
+  }
+  let streams
+  if (
+    req.headers['content-type'] &&
+                req.headers['content-type'].indexOf('application/json') > -1
+  ) {
+    streams = req.body.timeseries
+  } else if (
+    req.headers['content-type'] &&
+                req.headers['content-type'].indexOf('application/x-protobuf') > -1
+  ) {
+    streams = req.body.timeseries
+  }
+  if (streams) {
+    streams.forEach(function (stream) {
+      let finger = null
+      try {
+        let JSONLabels
+        try {
+            JSONLabels = stream.labels[0]
+        } catch (e) {
+          console.error(e)
+          return
+        }
+        // Calculate Fingerprint
+        finger = self.fingerPrint(JSON.stringify(JSONLabels))
+        if (self.debug) { console.log('LABELS FINGERPRINT', stream.labels, finger) }
+        self.labels.add(finger, stream.labels)
+        // Store Fingerprint
+        self.bulk_labels.add(finger, [
+          new Date().toISOString().split('T')[0],
+          finger,
+          JSON.stringify(JSONLabels),
+          JSONLabels.name || ''
+        ])
+        for (const key in JSONLabels) {
+          if (self.debug) { console.log('Storing label', key, JSONLabels[key]) }
+          self.labels.add('_LABELS_', key)
+          self.labels.add(key, JSONLabels[key])
+        }
+      } catch (e) {
+        console.log(e)
+      }
+
+      if (stream.samples) {
+        stream.samples.forEach(function (entry) {
+          if (self.debug) console.log('BULK ROW', entry, finger)
+          if (
+            !entry &&
+            !entry.timestamp &&
+            !entry.value
+          ) {
+            console.error('no bulkable data', entry)
+            return
+          }
+          const values = [
+            finger,
+            entry.timestamp,
+            entry.value,
+            JSONLabels.name || ''
+          ]
+          self.bulk.add(finger, values)
+        })
+      }
+    })
+  }
+  res.code(204).send()
+}
+
+module.exports = handler

--- a/lib/prompb.proto
+++ b/lib/prompb.proto
@@ -1,0 +1,68 @@
+syntax = "proto3";
+package prometheus;
+
+option go_package = "prompb";
+
+message WriteRequest {
+  repeated prometheus.TimeSeries timeseries = 1;
+}
+
+message ReadRequest {
+  repeated Query queries = 1;
+}
+
+message ReadResponse {
+  // In same order as the request's queries.
+  repeated QueryResult results = 1;
+}
+
+message Query {
+  int64 start_timestamp_ms = 1;
+  int64 end_timestamp_ms = 2;
+  repeated prometheus.LabelMatcher matchers = 3;
+  prometheus.ReadHints hints = 4;
+}
+
+message QueryResult {
+  // Samples within a time series must be ordered by time.
+  repeated prometheus.TimeSeries timeseries = 1;
+}
+
+message Sample {
+  double value    = 1;
+  int64 timestamp = 2;
+}
+
+message TimeSeries {
+  repeated Label labels   = 1;
+  repeated Sample samples = 2;
+}
+
+message Label {
+  string name  = 1;
+  string value = 2;
+}
+
+message Labels {
+  repeated Label labels = 1;
+}
+
+// Matcher specifies a rule, which can match or set of labels or not.
+message LabelMatcher {
+  enum Type {
+    EQ  = 0;
+    NEQ = 1;
+    RE  = 2;
+    NRE = 3;
+  }
+  Type type    = 1;
+  string name  = 2;
+  string value = 3;
+}
+
+message ReadHints {
+  int64 step_ms = 1;  // Query step size in milliseconds.
+  string func = 2;    // String representation of surrounding function or aggregation.
+  int64 start_ms = 3; // Start time in milliseconds.
+  int64 end_ms = 4;   // End time in milliseconds.
+}

--- a/test/promwrite.sh
+++ b/test/promwrite.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Execute inside promremotecli folder
+# see https://github.com/m3dbx/prometheus_remote_client_golang
+rand=`awk -v min=1 -v max=10 'BEGIN{srand(); print int(min+rand()*(max-min+1))}'`
+dd=`date +%s`
+go run main.go -u http://localhost:3100/api/v1/prom/remote/write -t http:metrics -d $dd,$rand


### PR DESCRIPTION
Implements support for the Prometheus Remote Write via Protobuf WriteRequest format

- [x] `api/v1/prom/remote/write`
- [x] `api/prom/remote/write` _(alias)_

Metrics are stored in the value column _(unwrap_value)_

#### Notes 
- Validated using [promremote](https://github.com/m3dbx/prometheus_remote_client_golang) from M3DB
- Self-Testing [Endpoint](https://tracing.glitch.me/test)
- 
![image](https://user-images.githubusercontent.com/1423657/150554482-988b5ccf-225c-4919-bc31-6fa18bef6f53.png)
