### PR TITLE
survive errors in cliql queries

### DIFF
--- a/lib/handlers/errors.js
+++ b/lib/handlers/errors.js
@@ -28,9 +28,9 @@ const handler = (err, req, res) => {
     return
   }
   if (res.raw.statusCode < 500) {
-    throw err
+    console.log(err)
+    // throw err
   }
-  console.log(err)
   res.send({
     statusCode: 500,
     error: 'Internal Server Error',


### PR DESCRIPTION
Query errors of any type cause cliql queries to crash cloki. PR to bypass this condition and seek comments.
```
Error: Code: 47. DB::Exception: Missing columns: 'Airtime' while processing query: 'SELECT (intDiv(toUInt32(toDateTime(FlightDate)), 300) * 300) * 1000 AS t, Carrier, sum(Airtime) AS c FROM default.ontime PREWHERE (toDateTime(FlightDate) >= 1642865280) AND (toDateTime(FlightDate) <= 1642868880) GROUP BY t, Carrier ORDER BY t ASC, Carrier ASC', required columns: 'Carrier' 'FlightDate' 'Airtime', maybe you meant: ['Carrier','FlightDate','AirTime']. (UNKNOWN_IDENTIFIER) (version 21.12.2.17 (official build))

at parseError (/usr/src/cloki/node_modules/@apla/clickhouse/src/parse-error.js:2:15)
at errorHandler (/usr/src/cloki/node_modules/@apla/clickhouse/src/clickhouse.js:29:13)
at IncomingMessage.<anonymous> (/usr/src/cloki/node_modules/@apla/clickhouse/src/clickhouse.js:97:11)
at IncomingMessage.emit (events.js:412:35)
at endReadableNT (internal/streams/readable.js:1334:12)
at processTicksAndRejections (internal/process/task_queues.js:82:21)
```