### PR TITLE
added crypto module and added uuidv4 function

### DIFF
--- a/lib/db/watcher.js
+++ b/lib/db/watcher.js
@@ -1,4 +1,5 @@
 const transpiler = require('../../parser/transpiler')
+const crypto = require('crypto')
 const EventEmitter = require('events')
 const UTILS = require('../utils')
 const { queryFingerprintsScan, createLiveView, watchLiveView } = require('./clickhouse')
@@ -12,7 +13,7 @@ module.exports = class extends EventEmitter {
     this.step = UTILS.parseOrDefault(request.step, 5) * 1000
     const self = this
     this.working = true
-    this.uid = Math.random()
+    this.uid = crypto.randomUUID()
     this.initQuery().catch(e => {
       if (self.working) {
         self.emit('error', e.message + '\n' + e.stack)


### PR DESCRIPTION
To remove security notice on using 'unsafe' randomness, we can switch this Math.random to crypto.randomUUID(), which returns a UUID v4 string.