### PR TITLE
Move to a proper logging library

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Check out the [Wiki](https://github.com/lmangani/cLoki/wiki) for detailed instru
 Clone this repository, install with `npm`and run using `nodejs` 14.x *(or higher)*
 ```bash
 npm install
-CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="cloki" node ./cloki.js
+CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="cloki" node cloki.js
 ```
 ##### :busstop: NPM
 Install `cloki` as global package on your system using `npm`
@@ -149,6 +149,9 @@ For a fully working demo, check the [docker-compose](https://github.com/lmangani
 
 --------------
 
+#### Logging
+The project uses [pino](https://github.com/pinojs/pino) for logging and by default outputs JSON'ified log lines. If you want to see "pretty" log lines you can start cloki with `npm run pretty`
+
 #### Configuration
 The following ENV Variables can be used to control cLoki parameters and backend settings.
 
@@ -167,15 +170,16 @@ The following ENV Variables can be used to control cLoki parameters and backend 
 | SAMPLES_DAYS  	| 7  	    	    | Max Days before Timeseries rotation  		|
 | HOST 			| 0.0.0.0 	    | cLOKi API IP  		|
 | PORT  		| 3100 	            | cLOKi API PORT  		|
-| CLOKI_LOGIN           | false             | Basic HTTP Username           |
-| CLOKI_PASSWORD        | false             | Basic HTTP Password           |
+| CLOKI_LOGIN           | undefined             | Basic HTTP Username           |
+| CLOKI_PASSWORD        | undefined             | Basic HTTP Password           |
 | READONLY  			| false  	    | Readonly Mode, no DB Init  		|
 | FASTIFY_BODYLIMIT | 5242880   | API Maximum payload size in bytes |
 | FASTIFY_REQUESTTIMEOUT | 0 | API Maximum Request Timeout in ms |
 | FASTIFY_MAXREQUESTS | 0 | API Maximum Requests per socket |
 | TEMPO_SPAN | 24 | Default span for Tempo queries in hours |
 | TEMPO_TAGTRACE | false | Optional tagging of TraceID (expensive) |
-| DEBUG  			| false  	    | Debug Mode  		|
+| DEBUG  			| false  	    | Debug Mode (for backwards compatibility) 		|
+| LOG_LEVEL  			| info  	    | Log Level  		|
 
 
 ------------

--- a/lib/db/alerting/alertWatcher/alertWatcher.js
+++ b/lib/db/alerting/alertWatcher/alertWatcher.js
@@ -5,6 +5,7 @@ const {
 const { durationToMs, parseLabels, errors } = require('../../../../common')
 const { alert } = require('../alertmanager')
 const compiler = require('../../../../parser/bnf')
+const logger = require('../../../logger')
 
 class AlertWatcher {
   /**
@@ -70,12 +71,10 @@ class AlertWatcher {
       this.lastCheck = await this._checkViews()
       this.health = 'ok'
       this.lastError = ''
-    } catch (e) {
-      console.error(e.message)
-      console.error(e.stack)
-      console.error(e.data)
+    } catch (err) {
+      logger.error({ err })
       this.health = 'error'
-      this.lastError = e.message
+      this.lastError = err.message
     }
   }
 

--- a/lib/db/alerting/index.js
+++ b/lib/db/alerting/index.js
@@ -6,6 +6,7 @@ const {
   putAlertRule
 } = require('../clickhouse_alerting')
 const factory = require('./alertWatcher')
+const logger = require('../../logger')
 let enabled = false
 /**
  *
@@ -190,7 +191,7 @@ module.exports.startAlerting = async () => {
       g.name.group === rule.name.group
     )
     if (!group) {
-      console.log(`Not found group for rule ${JSON.stringify(rule)}`)
+      logger.info({ rule }, 'Not found group for rule')
       continue
     }
     const w = factory(rule.name.ns, group.group, rule.rule)

--- a/lib/db/clickhouse.js
+++ b/lib/db/clickhouse.js
@@ -3,8 +3,8 @@
  * (C) 2018-2022 QXIP BV
  */
 
-const debug = process.env.DEBUG || false
 const UTILS = require('../utils')
+const logger = require('../logger')
 const toJSON = UTILS.toJSON
 
 /* DB Helper */
@@ -118,7 +118,7 @@ const labels = recordCache({
 
 /* Initialize */
 const initialize = function (dbName) {
-  console.log('Initializing DB...', dbName)
+  logger.info('Initializing DB... %s', dbName)
   const dbQuery = 'CREATE DATABASE IF NOT EXISTS ' + dbName
   const tmp = { ...clickhouseOptions, queryOptions: { database: '' } }
   ch = new ClickHouse(tmp)
@@ -135,13 +135,13 @@ const initialize = function (dbName) {
   return new Promise((resolve, reject) => {
     ch.query(dbQuery, undefined, async function (err/*, data */) {
       if (err) {
-        console.error('error', err)
+        logger.error({ err }, 'error initialising clickhouse')
         reject(err)
         return
       }
       const ch = new ClickHouse(clickhouseOptions)
       hackCh(ch)
-      console.log('CREATE TABLES', dbName)
+      logger.info('CREATE TABLES %s', dbName)
 
       let tsTable = 'CREATE TABLE IF NOT EXISTS ' + dbName + '.time_series (date Date,fingerprint UInt64,labels String, name String) ENGINE = ReplacingMergeTree(date) PARTITION BY date ORDER BY fingerprint'
       let smTable = 'CREATE TABLE IF NOT EXISTS ' + dbName + `.${samplesTableName} (fingerprint UInt64,timestamp_ms Int64,value Float64,string String) ENGINE = MergeTree PARTITION BY toRelativeHourNum(toDateTime(timestamp_ms / 1000)) ORDER BY (timestamp_ms)`
@@ -149,7 +149,7 @@ const initialize = function (dbName) {
       const settingsTable = 'CREATE TABLE IF NOT EXISTS ' + dbName + '.settings (fingerprint UInt64, type String, name String, value String, inserted_at DateTime64(9, \'UTC\')) ENGINE = ReplacingMergeTree(inserted_at) ORDER BY fingerprint'
 
       if (storagePolicy) {
-        console.log('ADD SETTINGS storage policy', storagePolicy)
+        logger.info('ADD SETTINGS storage policy %s', storagePolicy)
         const setStorage = ` SETTINGS storagePolicy='${storagePolicy}'`
         tsTable += setStorage
         smTable += setStorage
@@ -157,30 +157,34 @@ const initialize = function (dbName) {
 
       await ch.query(tsTable, undefined, function (err/*, data */) {
         if (err) {
-          console.log(err)
+          logger.info(err)
           process.exit(1)
-        } else if (debug) console.log('Timeseries Table ready!')
+        }
+        logger.debug('Timeseries Table ready!')
         return true
       })
       await ch.query(smTable, undefined, function (err/*, data */) {
         if (err) {
-          console.log(err)
+          logger.info(err)
           process.exit(1)
-        } else if (debug) console.log('Samples Table ready!')
+        }
+        logger.debug('Samples Table ready!')
         return true
       })
       await ch.query(readTable, undefined, function (err) {
         if (err) {
-          console.log(err)
+          logger.info(err)
           process.exit(1)
-        } else if (debug) console.log('Samples Table ready!')
+        }
+        logger.debug('Samples Table ready!')
         return true
       })
       await ch.query(settingsTable, undefined, function (err) {
         if (err) {
-          console.log(err)
+          logger.info(err)
           process.exit(1)
-        } else if (debug) console.log('Samples Table ready!')
+        }
+        logger.debug('Samples Table ready!')
         return true
       })
 
@@ -188,11 +192,18 @@ const initialize = function (dbName) {
         const alterTable = 'ALTER TABLE ' + dbName + `.${samplesTableName} MODIFY SETTING ttl_only_drop_parts = 1, merge_with_ttl_timeout = 3600, index_granularity = 8192`
         const rotateTable = 'ALTER TABLE ' + dbName + `.${samplesTableName} MODIFY TTL toDateTime(timestamp_ms / 1000)  + INTERVAL ` + rotationSamples + ' DAY'
         await ch.query(alterTable, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Samples Table altered for rotation!')
-          // return true;
+          if (err) {
+            logger.error({ err }, 'Error altering table')
+            return
+          }
+          logger.debug('Samples Table altered for rotation!')
         })
         await ch.query(rotateTable, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Samples Table rotation set to days: ' + rotationSamples)
+          if (err) {
+            logger.error(err)
+            return
+          }
+          logger.debug(`Samples Table rotation set to days: ${rotationSamples}`)
           return true
         })
       }
@@ -201,26 +212,42 @@ const initialize = function (dbName) {
         const alterTable = 'ALTER TABLE ' + dbName + '.time_series MODIFY SETTING ttl_only_drop_parts = 1, merge_with_ttl_timeout = 3600, index_granularity = 8192'
         const rotateTable = 'ALTER TABLE ' + dbName + '.time_series MODIFY TTL date  + INTERVAL ' + rotationLabels + ' DAY'
         await ch.query(alterTable, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Labels Table altered for rotation!')
+          if (err) {
+            logger.error({ err }, 'Error altering tables')
+            return
+          }
+          logger.debug('Labels Table altered for rotation!')
           return true
         })
         await ch.query(rotateTable, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Labels Table rotation set to days: ' + rotationLabels)
+          if (err) {
+            logger.error({ err })
+            return
+          }
+          logger.debug(`Labels Table rotation set to days: ${rotationLabels}`)
           return true
         })
       }
 
       if (storagePolicy) {
-        console.log('ALTER storage policy', storagePolicy)
+        logger.info('ALTER storage policy %s', storagePolicy)
         const alterTs = `ALTER TABLE ${dbName}.time_series MODIFY SETTING storagePolicy='${storagePolicy}'`
         const alterSm = `ALTER TABLE ${dbName}.${samplesTableName} MODIFY SETTING storagePolicy='${storagePolicy}'`
 
         await ch.query(alterTs, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Storage policy update for fingerprints ' + storagePolicy)
+          if (err) {
+            logger.error({ err }, 'Error updating storage policy for fingerprints')
+            return
+          }
+          logger.debug(`Storage policy update for fingerprints ${storagePolicy}`)
           return true
         })
         await ch.query(alterSm, undefined, function (err/*, data */) {
-          if (err) { console.log(err) } else if (debug) console.log('Storage policy update for samples ' + storagePolicy)
+          if (err) {
+            logger.error({ err }, 'Error updating storage policy for samples')
+            return
+          }
+          logger.debug(`Storage policy update for samples ${storagePolicy}`)
           return true
         })
       }
@@ -258,20 +285,20 @@ const initialize = function (dbName) {
 }
 
 const checkCapabilities = async () => {
-  console.log('Checking clickhouse capabilities: ')
+  logger.info('Checking clickhouse capabilities')
   try {
     await axios.post(getClickhouseUrl() + '/?allow_experimental_live_view=1',
       `CREATE LIVE VIEW ${clickhouseOptions.queryOptions.database}.lvcheck WITH TIMEOUT 1 AS SELECT 1`)
     capabilities.liveView = true
-    console.log('LIVE VIEW: supported')
+    logger.info('LIVE VIEW: supported')
   } catch (e) {
-    console.log('LIVE VIEW: unsupported')
+    logger.info('LIVE VIEW: unsupported')
     capabilities.liveView = false
   }
 }
 
 const reloadFingerprints = function () {
-  console.log('Reloading Fingerprints...')
+  logger.info('Reloading Fingerprints...')
   const selectQuery = `SELECT DISTINCT fingerprint, labels FROM ${clickhouseOptions.queryOptions.database}.time_series`
   const stream = ch.query(selectQuery)
   // or collect records yourself
@@ -283,7 +310,7 @@ const reloadFingerprints = function () {
     rows.push(row)
   })
   stream.on('error', function (err) {
-    console.log(err)
+    logger.error({ err }, 'Error reloading fingerprints')
   })
   stream.on('end', function () {
     rows.forEach(function (row) {
@@ -291,27 +318,27 @@ const reloadFingerprints = function () {
         const JSONLabels = toJSON(row[1].replace(/\!?=/g, ':'))
         labels.add(row[0], JSON.stringify(JSONLabels))
         for (const key in JSONLabels) {
-          // if (debug) console.log('Adding key',row);
+          // logger.debug('Adding key',row);
           labels.add('_LABELS_', key)
           labels.add(key, JSONLabels[key])
         }
-      } catch (e) { console.error(e) }
+      } catch (err) { logger.error({ err }, 'error reloading fingerprints') }
     })
-    if (debug) console.log('Reloaded fingerprints:', rows.length + 1)
+    logger.debug('Reloaded fingerprints: %s', rows.length + 1)
   })
 }
 
 const fakeStats = { summary: { bytesProcessedPerSecond: 0, linesProcessedPerSecond: 0, totalBytesProcessed: 0, totalLinesProcessed: 0, execTime: 0.001301608 }, store: { totalChunksRef: 0, totalChunksDownloaded: 0, chunksDownloadTime: 0, headChunkBytes: 0, headChunkLines: 0, decompressedBytes: 0, decompressedLines: 0, compressedBytes: 0, totalDuplicates: 0 }, ingester: { totalReached: 1, totalChunksMatched: 0, totalBatches: 0, totalLinesSent: 0, headChunkBytes: 0, headChunkLines: 0, decompressedBytes: 0, decompressedLines: 0, compressedBytes: 0, totalDuplicates: 0 } }
 
 const scanFingerprints = async function (query, res) {
-  if (debug) console.log('Scanning Fingerprints...')
+  logger.debug('Scanning Fingerprints...')
   const _query = transpiler.transpile(query)
   _query.step = UTILS.parseOrDefault(query.step, 5) * 1000
   return queryFingerprintsScan(_query, res)
 }
 
 const instantQueryScan = async function (query, res) {
-  if (debug) console.log('Scanning Fingerprints...')
+  logger.debug('Scanning Fingerprints...')
   const time = parseMs(query.time, Date.now())
   query.start = (time - 10 * 60 * 1000) * 1000000
   query.end = Date.now() * 1000000
@@ -331,10 +358,10 @@ const instantQueryScan = async function (query, res) {
 }
 
 const tempoQueryScan = async function (query, res, traceId) {
-  if (debug) console.log('Scanning Tempo Fingerprints...', traceId)
+  logger.debug('Scanning Tempo Fingerprints... %s', traceId)
   const time = parseMs(query.time, Date.now())
   /* Tempo does not seem to pass start/stop parameters. Use ENV or default 24h */
-  var hours = this.tempo_span || 24
+  const hours = this.tempo_span || 24
   if (!query.start) query.start = (time - (hours * 60 * 60 * 1000)) * 1000000
   if (!query.end) query.end = Date.now() * 1000000
   const _query = transpiler.transpile(query)
@@ -347,7 +374,7 @@ const tempoQueryScan = async function (query, res, traceId) {
     }
   )
   const dataStream = preprocessStream(_stream, _query.stream || [])
-  console.log('debug tempo', query)
+  logger.info('debug tempo', query)
   return await (outputTempoSpans(dataStream, res, traceId))
 }
 
@@ -363,9 +390,9 @@ function getClickhouseUrl () {
  * @returns {Promise<void>}
  */
 const queryFingerprintsScan = async function (query, res) {
-  if (debug) console.log('Scanning Fingerprints...')
+  logger.debug('Scanning Fingerprints...')
 
-  // console.log(_query.query);
+  // logger.info(_query.query);
   const _stream = await getClickhouseStream(query)
   const dataStream = preprocessStream(_stream, query.stream || [])
   return await (query.matrix
@@ -642,7 +669,7 @@ const preprocessStream = (rawStream, processors) => {
           : parseLabels(chunk.labels)
         return { ...chunk, labels: labels }
       } catch (e) {
-        console.log(chunk)
+        logger.info(chunk)
         return chunk
       }
     }, DataStream)
@@ -656,7 +683,7 @@ const preprocessStream = (rawStream, processors) => {
 
 /* cLoki Metrics Column */
 const scanMetricFingerprints = function (settings, client, params) {
-  if (debug) console.log('Scanning Clickhouse...', settings)
+  logger.debug({ settings }, 'Scanning Clickhouse...')
   // populate matrix structure
   const resp = {
     status: 'success',
@@ -701,7 +728,7 @@ const scanMetricFingerprints = function (settings, client, params) {
   }
   template += ' AND value > 0 ORDER BY timestamp_ms) GROUP BY ' + tags.join(', ')
 
-  if (debug) console.log('CLICKHOUSE METRICS SEARCH QUERY', template)
+  logger.debug('CLICKHOUSE METRICS SEARCH QUERY %s', template)
 
   const stream = ch.query(template)
   // or collect records yourself
@@ -717,7 +744,7 @@ const scanMetricFingerprints = function (settings, client, params) {
     client.code(400).send(err)
   })
   stream.on('end', function () {
-    if (debug) console.log('CLICKHOUSE RESPONSE:', rows)
+    logger.debug({ rows }, 'CLICKHOUSE RESPONSE')
     if (!rows || rows.length < 1) {
       resp.data.result = []
       resp.data.stats = fakeStats
@@ -739,9 +766,9 @@ const scanMetricFingerprints = function (settings, client, params) {
           })
           resp.data.result.push(metrics)
         })
-      } catch (e) { console.log(e) }
+      } catch (err) { logger.error({ err }, 'Error scanning fingerprints') }
     }
-    if (debug) console.log('CLOKI RESPONSE', JSON.stringify(resp))
+    logger.debug({ resp }, 'CLOKI RESPONSE')
     client.send(resp)
   })
 }
@@ -766,7 +793,7 @@ const scanMetricFingerprints = function (settings, client, params) {
  * }}
  */
 const scanClickhouse = function (settings, client, params) {
-  if (debug) console.log('Scanning Clickhouse...', settings)
+  logger.debug('Scanning Clickhouse...', settings)
 
   // populate matrix structure
   const resp = {
@@ -810,7 +837,7 @@ const scanClickhouse = function (settings, client, params) {
   }
   template += ' GROUP BY t, ' + settings.tag + ' ORDER BY t, ' + settings.tag + ')'
   template += ' GROUP BY ' + settings.tag + ' ORDER BY ' + settings.tag
-  if (debug) console.log('CLICKHOUSE SEARCH QUERY', template)
+  logger.debug('CLICKHOUSE SEARCH QUERY %s', template)
 
   // Read-Only: Initiate a new driver connection
   if (process.env.READONLY) {
@@ -832,7 +859,7 @@ const scanClickhouse = function (settings, client, params) {
     client.code(400).send(err)
   })
   stream.on('end', function () {
-    if (debug) console.log('CLICKHOUSE RESPONSE:', rows)
+    logger.debug({ rows }, 'CLICKHOUSE RESPONSE')
     if (!rows || rows.length < 1) {
       resp.data.result = []
       resp.data.stats = fakeStats
@@ -854,9 +881,9 @@ const scanClickhouse = function (settings, client, params) {
           })
           resp.data.result.push(metrics)
         })
-      } catch (e) { console.log(e) }
+      } catch (err) { logger.error({ err }, 'error scanning clickhouse') }
     }
-    if (debug) console.log('CLOKI RESPONSE', JSON.stringify(resp))
+    logger.debug({ resp }, 'CLOKI RESPONSE')
     client.send(resp)
   })
 }
@@ -877,9 +904,8 @@ const getSeries = async (matches, res) => {
     }
     try {
       return JSON.parse(l)
-    } catch (e) {
-      console.log(l)
-      console.log(e)
+    } catch (err) {
+      logger.error({ line: l, err }, 'Error parsing line')
       return null
     }
   }, DataStream).filter(e => e)
@@ -960,7 +986,7 @@ module.exports.watchLiveView = async (name, db, res, options) => {
 module.exports.createMV = async (query, id, url) => {
   const request = `CREATE MATERIALIZED VIEW ${clickhouseOptions.queryOptions.database}.${id} ` +
     `ENGINE = URL('${url}', JSON) AS ${query}`
-  console.log('MV: ' + request)
+  logger.info(`MV: ${request}`)
   await axios.post(`${getClickhouseUrl()}`, request)
 }
 

--- a/lib/db/throttler.js
+++ b/lib/db/throttler.js
@@ -2,6 +2,7 @@ const { isMainThread, parentPort } = require('worker_threads')
 const axios = require('axios')
 const { getClickhouseUrl, samplesTableName } = require('./clickhouse')
 const clickhouseOptions = require('./clickhouse').databaseOptions
+const logger = require('../logger')
 class TimeoutThrottler {
   constructor (statement) {
     this.statement = statement
@@ -14,16 +15,9 @@ class TimeoutThrottler {
     try {
       await this._flush()
       this.resolvers.forEach(r => r())
-    } catch (e) {
-      if (e.response) {
-        console.log('AXIOS ERROR')
-        console.log(e.message)
-        console.log(e.response.status)
-        console.log(e.response.data)
-      } else {
-        console.log(e)
-      }
-      this.rejects.forEach(r => r(e))
+    } catch (err) {
+      logger.error({ err }, 'AXIOS ERROR')
+      this.rejects.forEach(r => r(err))
     }
     this.resolvers = []
     this.rejects = []
@@ -69,15 +63,8 @@ if (isMainThread) {
       try {
         await timeSeriesThrottler.flush()
         await samplesThrottler.flush()
-      } catch (e) {
-        if (e.response) {
-          console.log('AXIOS ERROR')
-          console.log(e.message)
-          console.log(e.response.status)
-          console.log(e.response.data)
-        } else {
-          console.log(e)
-        }
+      } catch (err) {
+        logger.error({ err }, 'AXIOS ERROR')
       }
       const p = Date.now() - ts
       if (p < 100) {

--- a/lib/db/watcher.js
+++ b/lib/db/watcher.js
@@ -4,7 +4,7 @@ const EventEmitter = require('events')
 const UTILS = require('../utils')
 const { queryFingerprintsScan, createLiveView, watchLiveView } = require('./clickhouse')
 const { capabilities, samplesTableName } = require('./clickhouse')
-
+const logger = require('../logger')
 module.exports = class extends EventEmitter {
   constructor (request) {
     super()
@@ -38,10 +38,9 @@ module.exports = class extends EventEmitter {
         this.cancel = cancel
         await promise
       }
-    } catch (e) {
-      e.message && console.log(e.message)
-      e.response && console.log(e.response.data)
-      throw e
+    } catch (err) {
+      logger.error({ err })
+      throw err
     }
   }
 

--- a/lib/handlers/404.js
+++ b/lib/handlers/404.js
@@ -1,5 +1,5 @@
 function handler (req, res) {
-  if (this.debug) console.log('unsupported', req.params, req.query, req.body)
+  req.log.debug('unsupported')
   res.send('404 Not Supported')
 }
 

--- a/lib/handlers/alterts_data.js
+++ b/lib/handlers/alterts_data.js
@@ -1,4 +1,5 @@
 const axios = require('axios')
+const logger = require('../logger')
 
 async function handler (req, res) {
   req.body = JSON.parse(req.body)
@@ -7,7 +8,7 @@ async function handler (req, res) {
     return
   }
   try {
-    console.log(`POSTING \`${process.env.ALERTMAN_URL}/api/v2/alerts\` ${req.body.data.length}`)
+    logger.info(`POSTING \`${process.env.ALERTMAN_URL}/api/v2/alerts\` ${req.body.data.length}`)
     await axios.post(`${process.env.ALERTMAN_URL}/api/v2/alerts`,
       req.body.data.map(d => ({
         labels: {
@@ -20,10 +21,9 @@ async function handler (req, res) {
         generatorURL: 'http://cLoki/alerts'
       }))
     )
-  } catch (e) {
-    console.log('SEND ERROR')
-    console.log(e.message)
-    throw e
+  } catch (err) {
+    logger.error({ err }, 'SEND ERROR')
+    throw err
   }
   res.send('ok')
 }

--- a/lib/handlers/errors.js
+++ b/lib/handlers/errors.js
@@ -28,7 +28,7 @@ const handler = (err, req, res) => {
     return
   }
   if (res.raw.statusCode < 500) {
-    console.log(err)
+    req.error({ err })
     // throw err
   }
   res.send({

--- a/lib/handlers/label.js
+++ b/lib/handlers/label.js
@@ -12,8 +12,8 @@
 */
 
 function handler (req, res) {
-  if (this.debug) console.log('GET /loki/api/v1/label')
-  if (this.debug) console.log('QUERY: ', req.query)
+  req.log.debug('GET /loki/api/v1/label')
+  req.log.debug('QUERY: %s', req.query)
   const allLabels = this.labels.get('_LABELS_')
   const resp = { status: 'success', data: allLabels }
   res.send(resp)

--- a/lib/handlers/label_values.js
+++ b/lib/handlers/label_values.js
@@ -12,8 +12,8 @@
 */
 
 function handler (req, res) {
-  if (this.debug) { console.log('GET /api/prom/label/' + req.params.name + '/values') }
-  if (this.debug) console.log('QUERY LABEL: ', req.params.name)
+  req.log.debug(`GET /api/prom/label/${req.params.name}/values`)
+  req.log.debug('QUERY LABEL: %s', req.params.name)
   const allValues = this.labels.get(req.params.name)
   const resp = { status: 'success', data: allValues }
   res.send(resp)

--- a/lib/handlers/prom_push.js
+++ b/lib/handlers/prom_push.js
@@ -14,14 +14,14 @@
 
 function handler (req, res) {
   const self = this
-  if (this.debug) console.log('POST /api/v1/prom/remote/write')
+  req.log.debug('POST /api/v1/prom/remote/write')
   if (!req.body) {
-    console.error('No Request Body!', req)
+    req.log.error('No Request Body!')
     res.code(500).send()
     return
   }
   if (this.readonly) {
-    console.error('Readonly! No push support.')
+    req.log.error('Readonly! No push support.')
     res.code(500).send()
     return
   }
@@ -37,13 +37,13 @@ function handler (req, res) {
         // let JSONLabels
         try {
           JSONLabels = stream.labels[0]
-        } catch (e) {
-          console.error(e)
+        } catch (err) {
+          req.log.error({ err })
           return
         }
         // Calculate Fingerprint
         finger = self.fingerPrint(JSON.stringify(JSONLabels))
-        if (self.debug) { console.log('LABELS FINGERPRINT', stream.labels, finger) }
+        req.log.debug({ labels: stream.labels, finger }, 'LABELS FINGERPRINT')
         self.labels.add(finger, stream.labels)
         // Store Fingerprint
         self.bulk_labels.add(finger, [
@@ -53,23 +53,23 @@ function handler (req, res) {
           JSONLabels.name || ''
         ])
         for (const key in JSONLabels) {
-          if (self.debug) { console.log('Storing label', key, JSONLabels[key]) }
+          req.log.error({ key, data: JSONLabels[key] }, 'Storing label')
           self.labels.add('_LABELS_', key)
           self.labels.add(key, JSONLabels[key])
         }
-      } catch (e) {
-        console.log(e)
+      } catch (err) {
+        req.log.error({ err })
       }
 
       if (stream.samples) {
         stream.samples.forEach(function (entry) {
-          if (self.debug) console.log('BULK ROW', entry, finger)
+          req.log.debug({ entry, finger }, 'BULK ROW')
           if (
             !entry &&
             !entry.timestamp &&
             !entry.value
           ) {
-            console.error('no bulkable data', entry)
+            req.log.error({ entry }, 'no bulkable data')
             return
           }
           const values = [

--- a/lib/handlers/push.js
+++ b/lib/handlers/push.js
@@ -86,9 +86,7 @@ function processStream (stream, labels, bulkLabels, bulkValues, toJSON, fingerPr
 
 async function handler (req, res) {
   const self = this
-  if (this.debug) console.log('POST /loki/api/v1/push')
-  if (this.debug) console.log('QUERY: ', req.query)
-  if (this.debug) console.log('BODY: ', req.body)
+  req.log.debug('POST /loki/api/v1/push')
   if (!req.body) {
     await processRawPush(req, self.labels, self.bulk_labels, self.bulk,
       self.toJSON, self.fingerPrint)
@@ -96,7 +94,7 @@ async function handler (req, res) {
     return
   }
   if (this.readonly) {
-    console.error('Readonly! No push support.')
+    req.log.error('Readonly! No push support.')
     res.code(500).send()
     return
   }
@@ -112,7 +110,7 @@ async function handler (req, res) {
   ) {
     // streams = messages.PushRequest.decode(req.body)
     streams = req.body
-    if (this.debug) console.log('GOT protoBuf', streams)
+    req.log.debug({ streams }, 'GOT protoBuf')
   }
   const promises = []
   if (streams) {

--- a/lib/handlers/query.js
+++ b/lib/handlers/query.js
@@ -1,7 +1,6 @@
 // Query Handler
 async function handler (req, res) {
-  if (this.debug) console.log('GET /loki/api/v1/query')
-  if (this.debug) console.log('QUERY: ', req.query)
+  req.log.debug('GET /loki/api/v1/query')
   const resp = { streams: [] }
   if (!req.query.query) {
     res.send(resp)
@@ -16,8 +15,8 @@ async function handler (req, res) {
       req.query,
       { res: res.raw }
     )
-  } catch (e) {
-    console.log(e)
+  } catch (err) {
+    req.log.error({ err })
     res.send(resp)
   }
 }

--- a/lib/handlers/query_range.js
+++ b/lib/handlers/query_range.js
@@ -12,8 +12,7 @@
 const { parseCliQL } = require('../cliql')
 
 async function handler (req, res) {
-  if (this.debug) console.log('GET /loki/api/v1/query_range')
-  if (this.debug) console.log('QUERY: ', req.query)
+  req.log.debug('GET /loki/api/v1/query_range')
   const params = req.query
   const resp = { streams: [] }
   if (!req.query.query) {
@@ -35,8 +34,8 @@ async function handler (req, res) {
         req.query,
         { res: res.raw }
       )
-    } catch (e) {
-      console.log(e)
+    } catch (err) {
+      req.log.error({ err })
       res.send(resp)
     }
   }

--- a/lib/handlers/tags.js
+++ b/lib/handlers/tags.js
@@ -12,8 +12,7 @@
 */
 
 function handler (req, res) {
-  if (this.debug) console.log('GET /api/search/tags')
-  if (this.debug) console.log('QUERY: ', req.query)
+  req.log.debug('GET /api/search/tags')
   const allLabels = this.labels.get('_LABELS_')
   const resp = { tagNames: allLabels }
   res.send(resp)

--- a/lib/handlers/tags_values.js
+++ b/lib/handlers/tags_values.js
@@ -11,9 +11,8 @@
 }
 */
 
-function handler (req, res) { 
-  if (this.debug) { console.log('GET /api/search/tag/' + req.params.name + '/values') }
-  if (this.debug) console.log('QUERY LABEL: ', req.params.name)
+function handler (req, res) {
+  req.log.debug(`GET /api/search/tag/${req.params.name}/values`)
   const allValues = this.labels.get(req.params.name)
   const resp = { tagValues: allValues }
   res.send(resp)

--- a/lib/handlers/tail.js
+++ b/lib/handlers/tail.js
@@ -1,4 +1,5 @@
 const Watcher = require('../db/watcher')
+const logger = require('../logger')
 
 module.exports = function handler (connection, res) {
   try {
@@ -7,7 +8,7 @@ module.exports = function handler (connection, res) {
       connection.socket.send(s)
     })
     w.on('error', err => {
-      console.log(err)
+      logger.error({ err })
       connection.socket.send(err)
       connection.end()
     })
@@ -15,7 +16,7 @@ module.exports = function handler (connection, res) {
       w.removeAllListeners('data')
       w.destroy()
     })
-  } catch (e) {
-    console.log(e)
+  } catch (err) {
+    logger.error({ err })
   }
 }

--- a/lib/handlers/telegraf.js
+++ b/lib/handlers/telegraf.js
@@ -9,15 +9,13 @@
 */
 
 function handler (req, res) {
-  if (this.debug) console.log('POST /telegraf')
-  if (this.debug) console.log('QUERY: ', req.query)
-  if (this.debug) console.log('BODY: ', req.body)
+  req.log.error('POST /telegraf')
   if (!req.body && !req.body.metrics) {
-    console.error('No Request Body!', req)
+    req.log.error('No Request Body!')
     return
   }
   if (this.readonly) {
-    console.error('Readonly! No push support.')
+    req.log.error('Readonly! No push support.')
     res.send(500)
     return
   }
@@ -25,7 +23,7 @@ function handler (req, res) {
   streams = req.body.metrics
   if (!Array.isArray(streams)) streams = [streams]
   if (streams) {
-    if (this.debug) console.log('influx', streams)
+    req.log.debug({ streams }, 'influx')
     streams.forEach(function (stream) {
       let finger = null
       try {
@@ -33,7 +31,7 @@ function handler (req, res) {
         JSONLabels.metric = stream.name
         // Calculate Fingerprint
         finger = this.fingerPrint(JSON.stringify(JSONLabels))
-        if (this.debug) { console.log('LABELS FINGERPRINT', JSONLabels, finger) }
+        req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
         this.labels.add(finger, stream.labels)
         // Store Fingerprint
         this.bulk_labels.add(finger, [
@@ -43,23 +41,23 @@ function handler (req, res) {
           stream.name || ''
         ])
         for (const key in JSONLabels) {
-          // if (this.debug) console.log('Storing label',key, JSONLabels[key]);
+          // req.log.debug({ key, data: JSONLabels[key] }, 'Storing label');
           this.labels.add('_LABELS_', key)
           this.labels.add(key, JSONLabels[key])
         }
-      } catch (e) {
-        console.log(e)
+      } catch (err) {
+        req.log.error({ err })
       }
 
       if (stream.fields) {
         Object.keys(stream.fields).forEach(function (entry) {
-          // if (this.debug) console.log('BULK ROW',entry,finger);
+          // req.log.debug({ entry, finger }, 'BULK ROW');
           if (
             !entry &&
             !stream.timestamp &&
             (!entry.value || !entry.line)
           ) {
-            console.error('no bulkable data', entry)
+            req.log.error({ entry }, 'no bulkable data')
             return
           }
           const values = [

--- a/lib/handlers/tempo_push.js
+++ b/lib/handlers/tempo_push.js
@@ -20,16 +20,14 @@
 
 function handler (req, res) {
   const self = this
-  if (this.debug) console.log('POST /tempo/api/push')
-  if (this.debug) console.log('QUERY: ', req.query)
-  if (this.debug) console.log('BODY: ', req.body)
+  req.log.debug('POST /tempo/api/push')
   if (!req.body) {
-    console.error('No Request Body!', req)
+    req.log.error('No Request Body!')
     res.code(500).send()
     return
   }
   if (this.readonly) {
-    console.error('Readonly! No push support.')
+    req.log.error('Readonly! No push support.')
     res.code(500).send()
     return
   }
@@ -44,14 +42,14 @@ function handler (req, res) {
                 req.headers['content-type'].indexOf('application/x-protobuf') > -1
   ) {
     streams = req.body
-    if (this.debug) console.log('GOT protoBuf', streams)
+    req.log.debug({ streams }, 'GOT protoBuf')
   } else {
     streams = req.body
   }
-  console.log('streams', streams);
+  req.log.info({ streams }, 'streams');
   if (streams) {
     streams.forEach(function (stream) {
-      if (self.debug) console.log('ingesting tempo stream', stream);
+      req.log.debug({ stream }, 'ingesting tempo stream');
       let finger = null
       try {
         let JSONLabels = {}
@@ -65,13 +63,13 @@ function handler (req, res) {
 	    }
 	  }
 	  JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
-        } catch (e) {
-          console.error(e)
+        } catch (err) {
+          req.log.error({ err })
           return
         }
         // Calculate Fingerprint
         finger = self.fingerPrint(JSON.stringify(JSONLabels))
-        if (self.debug) { console.log('LABELS FINGERPRINT', JSONLabels, finger) }
+        req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
         self.labels.add(finger, stream.labels)
         // Store Fingerprint
         self.bulk_labels.add([[
@@ -81,12 +79,12 @@ function handler (req, res) {
           JSONLabels.traceId || ''
         ]])
         for (const key in JSONLabels) {
-          if (self.debug) { console.log('Storing label', key, JSONLabels[key]) }
+          req.log.debug({ key, data: JSONLabels[key] }, 'Storing label')
           self.labels.add('_LABELS_', key)
           self.labels.add(key, JSONLabels[key])
         }
-      } catch (e) {
-        console.log('failed ingesting tempo stream', e)
+      } catch (err) {
+        req.log.error({ err }, 'failed ingesting tempo stream')
       }
 
       // Form Tempo Object - or shall we materialize this from CH?
@@ -108,16 +106,16 @@ function handler (req, res) {
         }
 	if(stream.localEndpoint) tempo.localEndpoint = stream.localEndpoint; // already in tags, deduplicate?
 	if(stream.parentId) tempo.parentSpanID = stream.parentId;
-	if (self.debug) console.log(tempo);
+	req.log.debug(tempo)
 	tempo = JSON.parse(JSON.stringify(tempo));
-      } catch(e) { console.log(e); return };
+      } catch(err) { req.log.error({ err }); return };
       // Store Tempo Object
       const values = [
             finger,
             parseInt(stream.timestamp/1000) || new Date().getTime(),
             parseInt(stream.duration) || null,
             JSON.stringify(tempo) || '' ]
-      if (self.debug) console.log('store', finger, values);
+      req.log.debug({ finger, values }, 'store');
       self.bulk.add([values])
     })
   }

--- a/lib/handlers/tempo_traces.js
+++ b/lib/handlers/tempo_traces.js
@@ -14,6 +14,8 @@ const protoBuff = require('protobufjs')
 const TraceDataType = protoBuff.loadSync(__dirname + '/../opentelemetry/proto/trace/v1/trace.proto')
   .lookupType('opentelemetry.proto.trace.v1.TracesData')
 
+const logger = require('../logger')
+
 function pad(pad, str, padLeft) {
   if (typeof str === 'undefined')
     return pad;
@@ -25,9 +27,7 @@ function pad(pad, str, padLeft) {
 }
 
 async function handler (req, res) {
-  if (this.debug) console.log('GET /api/traces/:traceId/:json')
-  if (this.debug) console.log('QUERY: ', req.query)
-  if (this.debug) console.log('PARAMS: ',req.params)
+  req.log.debug('GET /api/traces/:traceId/:json')
   const json_api = req.params.json || false;
   const resp = { data: [] }
   if (!req.params.traceId) {
@@ -38,7 +38,7 @@ async function handler (req, res) {
   if (this.tempo_tagtrace) req.query.query = `{traceId="${req.params.traceId}"}`
   else req.query.query = `{type="tempo"} |~ "${req.params.traceId}"`
 
-  if (this.debug) console.log('Scan Tempo', req.query, req.params.traceId);
+  req.log.debug('Scan Tempo', req.query, req.params.traceId);
   /* scan fingerprints */
   /* TODO: handle time tag + direction + limit to govern the query output */
   try {
@@ -46,7 +46,7 @@ async function handler (req, res) {
       req.query, res, req.params.traceId
     )
     let parsed = JSON.parse(resp);
-    if (this.debug) console.log('PARSED:', JSON.stringify(parsed));
+    req.log.debug({ parsed }, 'PARSED');
     if(!parsed.data[0] || !parsed.data[0].spans) throw new Error('no results');
     /* Basic Structure for traces/v1 Protobuf encoder */
     let struct = { resourceSpans: [] };
@@ -98,25 +98,25 @@ async function handler (req, res) {
         if (attributes.length > 0) protoJSON.resource.attributes = protoJSON.resource.attributes.concat(attributes)
 	/* Add to Protobuf-JSON struct */
 	struct.resourceSpans.push(protoJSON);
-	if (this.debug) console.log('push span', span);
+	req.log.debug({ span }, 'push span');
     });
 
     if(json_api){
 	    /* Send spans into JSON response */
-	    if (this.debug) console.log('PB-JSON', JSON.stringify(struct));
+	    req.log.debug({ struct }, 'PB-JSON');
     	    res.headers({'content-type': 'application/json'}).send(struct)
     } else {
 	    /* Pack spans into Protobuf response */
 	    let inside = TraceDataType.fromObject(struct);
 	    let proto = TraceDataType.encode(inside).finish();
-	    if (this.debug) console.log('PB-JSON', JSON.stringify(struct));
-	    if (this.debug) console.log('PB-HEX', Buffer.from(proto).toString('hex'));
+	    req.log.debug({ struct }, 'PB-JSON');
+	    req.log.debug({ proto: Buffer.from(proto).toString('hex') }, 'PB-HEX');
 	    res.header('Content-Type', 'application/x-protobuf')
 	    res.send(proto);
     }
 
-  } catch (e) {
-    console.log(e)
+  } catch (err) {
+    req.log.error({ err })
     res.headers({'content-type': 'application/json'}).send(resp)
   }
 }

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -9,7 +9,17 @@ if (process.env.DEBUG && !process.env.LOG_LEVEL) {
 
 const logger = pino({
   name: 'cloki',
-  level
+  level,
+  serializers: {
+    err: pino.stdSerializers.wrapErrorSerializer((err) => {
+      if (err.response) {
+        err.responseData = err.response.data
+        err.responseStatus = err.response.status
+        delete err.response
+      }
+      return err
+    })
+  }
 })
 
 module.exports = logger

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,7 +3,7 @@ const pino = require('pino')
 
 let level = process.env.LOG_LEVEL || 'info'
 
-if (process.env.DEBUG && process.env.LOG_LEVEL) {
+if (process.env.DEBUG && !process.env.LOG_LEVEL) {
   level = 'debug'
 }
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -1,0 +1,15 @@
+/* Logging */
+const pino = require('pino')
+
+let level = process.env.LOG_LEVEL || 'info'
+
+if (process.env.DEBUG && process.env.LOG_LEVEL) {
+  level = 'debug'
+}
+
+const logger = pino({
+  name: 'cloki',
+  level
+})
+
+module.exports = logger

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "handlebars-helpers": "^0.10.0",
         "jsonic": "^0.3.1",
         "patch-package": "^6.4.7",
+        "pino": "^7.6.5",
         "plugnplay": "^3.15.0",
         "protobufjs": "^6.11.2",
         "protocol-buffers": "^4.2.0",
@@ -53,6 +54,7 @@
         "fastify-serve-swagger-ui": "^1.0.0",
         "jest": "^27.4.5",
         "logfmt": "^1.3.2",
+        "pino-pretty": "^7.5.1",
         "standard": "^16.0.4"
       }
     },
@@ -1970,6 +1972,110 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "node_modules/args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "dependencies": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/args/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/camelcase": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+      "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/args/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/args/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/args/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/args/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/args/node_modules/leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/args/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -2749,6 +2855,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "node_modules/colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -3058,6 +3170,15 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
+    "node_modules/dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true,
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -3243,6 +3364,17 @@
         "node": ">=8"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "node_modules/easy-factory": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/easy-factory/-/easy-factory-1.3.0.tgz",
@@ -3290,6 +3422,14 @@
       "integrity": "sha512-GSK7qphNR4iPcejfAlZxKDoz3xMhnspwImK+Af5WhePS9jUpK/Oh7rUdyENWu+9rgDflOCTmAojBsgsvM8neAQ==",
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/enquirer": {
@@ -4531,6 +4671,37 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-3.0.0.tgz",
       "integrity": "sha512-ZdCvKEEd92DNLps5n0v231Bha8bkz1DjnPP/aEz37rz/q42Z5JVLmgnqR4DYuNn3NXAO3IDCPyRvgvxtJ4Ym4w=="
+    },
+    "node_modules/fastify/node_modules/pino": {
+      "version": "6.13.4",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
+      "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
+      "dependencies": {
+        "fast-redact": "^3.0.0",
+        "fast-safe-stringify": "^2.0.8",
+        "flatstr": "^1.0.12",
+        "pino-std-serializers": "^3.1.0",
+        "process-warning": "^1.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "sonic-boom": "^1.0.2"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/fastify/node_modules/pino-std-serializers": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+    },
+    "node_modules/fastify/node_modules/sonic-boom": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0",
+        "flatstr": "^1.0.12"
+      }
     },
     "node_modules/fastq": {
       "version": "1.13.0",
@@ -7340,6 +7511,15 @@
         }
       }
     },
+    "node_modules/joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true,
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -8076,6 +8256,15 @@
         "node": "*"
       }
     },
+    "node_modules/mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -8417,6 +8606,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "node_modules/on-finished": {
       "version": "2.3.0",
@@ -8844,26 +9038,61 @@
       }
     },
     "node_modules/pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.6.5.tgz",
+      "integrity": "sha512-38tAwlJ7HevMENHD5FZE+yxSlAH5Wg3FoOjbB3MX2j3/kgpOEkmDHhTVKkecR57qxD5doHo2yi9nac94gqqbiQ==",
       "dependencies": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
       },
       "bin": {
         "pino": "bin.js"
       }
     },
+    "node_modules/pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "dependencies": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-pretty": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.5.1.tgz",
+      "integrity": "sha512-xEOUJiokdBGcZ9d0v7OY6SqEp+rrVH2drE3bHOUsK8elw44eh9V83InZqeL1dFwgD1IDnd6crUoec3hIXxfdBQ==",
+      "dev": true,
+      "dependencies": {
+        "args": "^5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
+      },
+      "bin": {
+        "pino-pretty": "bin.js"
+      }
+    },
     "node_modules/pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "node_modules/pirates": {
       "version": "4.0.4",
@@ -9035,6 +9264,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "node_modules/process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "node_modules/progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -9151,6 +9385,16 @@
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
+    },
+    "node_modules/pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
     },
     "node_modules/punycode": {
       "version": "2.1.1",
@@ -9292,6 +9536,14 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==",
+      "engines": {
+        "node": ">= 12.13.0"
       }
     },
     "node_modules/record-cache": {
@@ -9614,6 +9866,14 @@
       "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg==",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/safer-buffer": {
@@ -10051,12 +10311,11 @@
       "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
     },
     "node_modules/sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "dependencies": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "node_modules/source-map": {
@@ -10172,6 +10431,14 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ==",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/sprintf-js": {
@@ -10626,6 +10893,11 @@
         "stream-chain": "^2.2.4"
       }
     },
+    "node_modules/stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "node_modules/string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -10913,6 +11185,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "node_modules/thread-stream": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.1.tgz",
+      "integrity": "sha512-+KNCqNxOSwYfXLtCIRDKQq29x9jvqnOFjYCPdB38sf4pT3QanPSNc8vRqMj+Q3z4tYIctb5opNZrMK/GwmgsAQ==",
+      "dependencies": {
+        "real-require": "^0.1.0"
+      }
     },
     "node_modules/throat": {
       "version": "6.0.1",
@@ -13409,6 +13689,88 @@
         "sprintf-js": "~1.0.2"
       }
     },
+    "args": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+      "integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+      "dev": true,
+      "requires": {
+        "camelcase": "5.0.0",
+        "chalk": "2.4.2",
+        "leven": "2.1.0",
+        "mri": "1.1.4"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "camelcase": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+          "dev": true
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "leven": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+          "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "arr-diff": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
@@ -14009,6 +14371,12 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
     },
+    "colorette": {
+      "version": "2.0.16",
+      "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.16.tgz",
+      "integrity": "sha512-hUewv7oMjCp+wkBv5Rm0v87eJhq4woh5rSR+42YSQJKecCqgIqNkZ6lAlQms/BwHPJA5NKMRlpxPRv0n8HQW6g==",
+      "dev": true
+    },
     "combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -14262,6 +14630,12 @@
         }
       }
     },
+    "dateformat": {
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
+      "integrity": "sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==",
+      "dev": true
+    },
     "debug": {
       "version": "4.3.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
@@ -14398,6 +14772,17 @@
         }
       }
     },
+    "duplexify": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.2.tgz",
+      "integrity": "sha512-fz3OjcNCHmRP12MJoZMPglx8m4rrFP8rovnk4vT8Fs+aonZoCwGg10dSsQsfP/E62eZcPTMSMP6686fu9Qlqtw==",
+      "requires": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.0"
+      }
+    },
     "easy-factory": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/easy-factory/-/easy-factory-1.3.0.tgz",
@@ -14434,6 +14819,14 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/encoding-negotiator/-/encoding-negotiator-2.0.1.tgz",
       "integrity": "sha512-GSK7qphNR4iPcejfAlZxKDoz3xMhnspwImK+Af5WhePS9jUpK/Oh7rUdyENWu+9rgDflOCTmAojBsgsvM8neAQ=="
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "enquirer": {
       "version": "2.3.6",
@@ -15212,6 +15605,36 @@
         "secure-json-parse": "^2.0.0",
         "semver": "^7.3.2",
         "tiny-lru": "^7.0.0"
+      },
+      "dependencies": {
+        "pino": {
+          "version": "6.13.4",
+          "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.4.tgz",
+          "integrity": "sha512-g4tHSISmQJYUEKEMVdaZ+ZokWwFnTwZL5JPn+lnBVZ1BuBbrSchrXwQINknkM5+Q4fF6U9NjiI8PWwwMDHt9zA==",
+          "requires": {
+            "fast-redact": "^3.0.0",
+            "fast-safe-stringify": "^2.0.8",
+            "flatstr": "^1.0.12",
+            "pino-std-serializers": "^3.1.0",
+            "process-warning": "^1.0.0",
+            "quick-format-unescaped": "^4.0.3",
+            "sonic-boom": "^1.0.2"
+          }
+        },
+        "pino-std-serializers": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
+          "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+        },
+        "sonic-boom": {
+          "version": "1.4.1",
+          "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
+          "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+          "requires": {
+            "atomic-sleep": "^1.0.0",
+            "flatstr": "^1.0.12"
+          }
+        }
       }
     },
     "fastify-basic-auth": {
@@ -17538,6 +17961,12 @@
         }
       }
     },
+    "joycon": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz",
+      "integrity": "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==",
+      "dev": true
+    },
     "js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -18118,6 +18547,12 @@
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
       "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
+    "mri": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+      "integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+      "dev": true
+    },
     "ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -18386,6 +18821,11 @@
         "define-properties": "^1.1.3",
         "es-abstract": "^1.19.1"
       }
+    },
+    "on-exit-leak-free": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-0.2.0.tgz",
+      "integrity": "sha512-dqaz3u44QbRXQooZLTUKU41ZrzYrcvLISVgbrzbyCMxpmSLJvZ3ZamIJIZ29P6OhZIkNIQKosdeM6t1LYbA9hg=="
     },
     "on-finished": {
       "version": "2.3.0",
@@ -18697,23 +19137,55 @@
       "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
     },
     "pino": {
-      "version": "6.13.3",
-      "resolved": "https://registry.npmjs.org/pino/-/pino-6.13.3.tgz",
-      "integrity": "sha512-tJy6qVgkh9MwNgqX1/oYi3ehfl2Y9H0uHyEEMsBe74KinESIjdMrMQDWpcZPpPicg3VV35d/GLQZmo4QgU2Xkg==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-7.6.5.tgz",
+      "integrity": "sha512-38tAwlJ7HevMENHD5FZE+yxSlAH5Wg3FoOjbB3MX2j3/kgpOEkmDHhTVKkecR57qxD5doHo2yi9nac94gqqbiQ==",
       "requires": {
         "fast-redact": "^3.0.0",
-        "fast-safe-stringify": "^2.0.8",
-        "fastify-warning": "^0.2.0",
-        "flatstr": "^1.0.12",
-        "pino-std-serializers": "^3.1.0",
+        "on-exit-leak-free": "^0.2.0",
+        "pino-abstract-transport": "v0.5.0",
+        "pino-std-serializers": "^4.0.0",
+        "process-warning": "^1.0.0",
         "quick-format-unescaped": "^4.0.3",
-        "sonic-boom": "^1.0.2"
+        "real-require": "^0.1.0",
+        "safe-stable-stringify": "^2.1.0",
+        "sonic-boom": "^2.2.1",
+        "thread-stream": "^0.13.0"
+      }
+    },
+    "pino-abstract-transport": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-0.5.0.tgz",
+      "integrity": "sha512-+KAgmVeqXYbTtU2FScx1XS3kNyfZ5TrXY07V96QnUSFqo2gAqlvmaxH67Lj7SWazqsMabf+58ctdTcBgnOLUOQ==",
+      "requires": {
+        "duplexify": "^4.1.2",
+        "split2": "^4.0.0"
+      }
+    },
+    "pino-pretty": {
+      "version": "7.5.1",
+      "resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-7.5.1.tgz",
+      "integrity": "sha512-xEOUJiokdBGcZ9d0v7OY6SqEp+rrVH2drE3bHOUsK8elw44eh9V83InZqeL1dFwgD1IDnd6crUoec3hIXxfdBQ==",
+      "dev": true,
+      "requires": {
+        "args": "^5.0.1",
+        "colorette": "^2.0.7",
+        "dateformat": "^4.6.3",
+        "fast-safe-stringify": "^2.0.7",
+        "joycon": "^3.1.1",
+        "pino-abstract-transport": "^0.5.0",
+        "pump": "^3.0.0",
+        "readable-stream": "^3.6.0",
+        "rfdc": "^1.3.0",
+        "secure-json-parse": "^2.4.0",
+        "sonic-boom": "^2.2.0",
+        "strip-json-comments": "^3.1.1"
       }
     },
     "pino-std-serializers": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-3.2.0.tgz",
-      "integrity": "sha512-EqX4pwDPrt3MuOAAUBMU0Tk5kR/YcCM5fNPEzgCO2zJ5HfX0vbiH9HbJglnyeQsN96Kznae6MWD47pZB5avTrg=="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-4.0.0.tgz",
+      "integrity": "sha512-cK0pekc1Kjy5w9V2/n+8MkZwusa6EyyxfeQCB799CQRhRt/CqYKiWs5adeu8Shve2ZNffvfC/7J64A2PJo1W/Q=="
     },
     "pirates": {
       "version": "4.0.4",
@@ -18844,6 +19316,11 @@
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
+    "process-warning": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-1.0.0.tgz",
+      "integrity": "sha512-du4wfLyj4yCZq1VupnVSZmRsPJsNuxoDQFdCFHLaYiEbFBD7QE0a+I4D7hOxrVnh78QE/YipFAj9lXHiXocV+Q=="
+    },
     "progress": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
@@ -18948,6 +19425,16 @@
       "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
       "dev": true
     },
+    "pump": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
@@ -19047,6 +19534,11 @@
       "requires": {
         "picomatch": "^2.2.1"
       }
+    },
+    "real-require": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.1.0.tgz",
+      "integrity": "sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg=="
     },
     "record-cache": {
       "version": "1.1.1",
@@ -19276,6 +19768,11 @@
           "integrity": "sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ=="
         }
       }
+    },
+    "safe-stable-stringify": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.3.1.tgz",
+      "integrity": "sha512-kYBSfT+troD9cDA85VDnHZ1rpHC50O0g1e6WlGHVCz/g+JS+9WKLj+XwFYyR8UbrZN8ll9HUpDAAddY58MGisg=="
     },
     "safer-buffer": {
       "version": "2.1.2",
@@ -19627,12 +20124,11 @@
       "integrity": "sha512-YIK6I2lsH072UE0aOFxxY1dPDCS43I5ktqHpeAsuLNYWkE5pGxRGWfDM4/vSUfNzXjC1Ivzt3qx31PCLmc9yqg=="
     },
     "sonic-boom": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-1.4.1.tgz",
-      "integrity": "sha512-LRHh/A8tpW7ru89lrlkU4AszXt1dbwSjVWguGrmlxE7tawVmDBlI1PILMkXAxJTwqhgsEeTHzj36D5CmHgQmNg==",
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-2.6.0.tgz",
+      "integrity": "sha512-6xYZFRmDEtxGqfOKcDQ4cPLrNa0SPEDI+wlzDAHowXE6YV42NeXqg9mP2KkiM8JVu3lHfZ2iQKYlGOz+kTpphg==",
       "requires": {
-        "atomic-sleep": "^1.0.0",
-        "flatstr": "^1.0.12"
+        "atomic-sleep": "^1.0.0"
       }
     },
     "source-map": {
@@ -19734,6 +20230,11 @@
           }
         }
       }
+    },
+    "split2": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.1.0.tgz",
+      "integrity": "sha512-VBiJxFkxiXRlUIeyMQi8s4hgvKCSjtknJv/LVYbrgALPwf5zSKmEwV9Lst25AkvMDnvxODugjdl6KZgwKM1WYQ=="
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -20064,6 +20565,11 @@
         "stream-chain": "^2.2.4"
       }
     },
+    "stream-shift": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ=="
+    },
     "string_decoder": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
@@ -20280,6 +20786,14 @@
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
       "dev": true
+    },
+    "thread-stream": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-0.13.1.tgz",
+      "integrity": "sha512-+KNCqNxOSwYfXLtCIRDKQq29x9jvqnOFjYCPdB38sf4pT3QanPSNc8vRqMj+Q3z4tYIctb5opNZrMK/GwmgsAQ==",
+      "requires": {
+        "real-require": "^0.1.0"
+      }
     },
     "throat": {
       "version": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "scripts": {
     "test": "jest",
     "start": "node cloki.js",
+    "pretty": "node cloki.js | pino-pretty",
     "postinstall": "patch-package",
     "lint": "npx eslint --fix *.js lib parser plugins test"
   },
@@ -44,6 +45,7 @@
     "handlebars-helpers": "^0.10.0",
     "jsonic": "^0.3.1",
     "patch-package": "^6.4.7",
+    "pino": "^7.6.5",
     "plugnplay": "^3.15.0",
     "protobufjs": "^6.11.2",
     "protocol-buffers": "^4.2.0",
@@ -68,6 +70,7 @@
     "fastify-serve-swagger-ui": "^1.0.0",
     "jest": "^27.4.5",
     "logfmt": "^1.3.2",
+    "pino-pretty": "^7.5.1",
     "standard": "^16.0.4"
   },
   "directories": {

--- a/parser/registry/line_format/index.js
+++ b/parser/registry/line_format/index.js
@@ -2,6 +2,7 @@ const hb = require('handlebars')
 const { addStream, isEOF } = require('../common')
 const { LineFmtOption } = require('../../../common')
 const { compile } = require('./go_native_fmt')
+const logger = require('../../../lib/logger')
 require('handlebars-helpers')(['math', 'string'], {
   handlebars: hb
 })
@@ -47,9 +48,9 @@ module.exports = (token, query) => {
       if (processor.then) {
         try {
           await processor
-        } catch (e) {
+        } catch (err) {
           processor = null
-          console.log(e)
+          logger.error({ err })
         }
       }
       try {

--- a/parser/registry/parser_registry/index.js
+++ b/parser/registry/parser_registry/index.js
@@ -2,6 +2,7 @@ const json = require('./json')
 const re = require('./regexp')
 const { hasExtraLabels, getPlugins, isEOF, hasStream, addStream } = require('../common')
 const logfmt = require('./logfmt')
+const logger = require('../../../lib/logger')
 
 module.exports = {
   /**
@@ -40,8 +41,8 @@ module.exports = {
     }
     try {
       return re.viaRequest(token, query)
-    } catch (e) {
-      console.log(e)
+    } catch (err) {
+      logger.error({ err })
       return re.viaStream(token, query)
     }
   },

--- a/parser/transpiler.js
+++ b/parser/transpiler.js
@@ -113,8 +113,6 @@ module.exports.transpile = (request) => {
   setQueryParam(query, sharedParamNames.samplesTable, `${DATABASE_NAME()}.${samplesReadTableName}`)
   setQueryParam(query, sharedParamNames.from, start)
   setQueryParam(query, sharedParamNames.to, end)
-
-  // console.log(query.toString())
   return {
     query: request.rawQuery ? query : query.toString(),
     matrix: !!query.ctx.matrix,


### PR DESCRIPTION
This change is not well tested yet.

This change brings in a proper log library called `pino`

It's already a part of `fastify`

This enables us to be able to log things out in a much nicer way for, ironically, log ingestion among other things
This change also adds a new env var called `LOG_LEVEL` so that people running the software have greater control over logging
For backwards compatibility `DEBUG` env var will set `LOG_LEVEL` to debug

Most obvious change will be that fastify logging is no longer disabled and will do an info level log on every request input and output
this can be disabled using the flag `disableRequestLogging` in fastify server setup

If you want to be able to see logs that aren't designed to be machine readable all of the time you can start up the process with `npm run pretty` which will start up the process with `pino-pretty` analysing the logs

Oh and I changed `CLOKI_LOGIN` and `CLOKI_PASSWORD` to be `undefined` by default, not `false` - it's bad convention to change a type of variable - you were going from `boolean` to be `string`, `undefined` did the same job.

OH and you'll see i changed a lot of `catch(e)` to `catch(err)` - that's because pino has a built in serializer for the key `err` and it should make it so all errors have keys of `err` instead of a mix of `e` and `err` and `error`