### PR TITLE
Replace short-hash with xxHash64 (should fix #113)

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,10 +19,11 @@ const labelParser = function (labels) {
   return { labels: output, regex: regex }
 }
 /* Fingerprinting */
-const shortHash = require('short-hash')
+const xxh = require('xxhashjs')
+const xxhSeed = 'cloki'
 const fingerPrint = function (text, hex) {
-  if (hex) return shortHash(text)
-  else return parseInt(shortHash(text), 16)
+  if (hex) return xxh.h64(text, xxhSeed).toString(16)
+  else return Number(xxh.h64(text, xxhSeed))
 }
 
 const toJSON = require('jsonic')

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,11 +33,11 @@
         "protocol-buffers-encodings": "^1.1.1",
         "record-cache": "^1.1.1",
         "scramjet": "^4.36.1",
-        "short-hash": "^1.0.0",
         "snappyjs": "^0.6.1",
         "stream-chain": "^2.2.4",
         "stream-json": "^1.7.3",
         "ws": "^8.4.0",
+        "xxhashjs": "^0.2.2",
         "yaml": "^1.10.2"
       },
       "bin": {
@@ -3123,6 +3123,11 @@
       "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
+    "node_modules/cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+    },
     "node_modules/data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -5807,11 +5812,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/hash-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
-      "integrity": "sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8="
     },
     "node_modules/helper-date": {
       "version": "1.0.1",
@@ -10087,14 +10087,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/short-hash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/short-hash/-/short-hash-1.0.0.tgz",
-      "integrity": "sha1-P0kdco/Md37GBbuvf4PyNxL0IFA=",
-      "dependencies": {
-        "hash-string": "^1.0.0"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -12127,6 +12119,14 @@
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "engines": {
         "node": ">=0.4"
+      }
+    },
+    "node_modules/xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "dependencies": {
+        "cuint": "^0.2.2"
       }
     },
     "node_modules/y18n": {
@@ -14591,6 +14591,11 @@
         }
       }
     },
+    "cuint": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cuint/-/cuint-0.2.2.tgz",
+      "integrity": "sha1-QICG1AlVDCYxFVYZ6fp7ytw7mRs="
+    },
     "data-urls": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-2.0.0.tgz",
@@ -16675,11 +16680,6 @@
           }
         }
       }
-    },
-    "hash-string": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/hash-string/-/hash-string-1.0.0.tgz",
-      "integrity": "sha1-w/oV8Hjd0WvBULQXb95wkWIPLH8="
     },
     "helper-date": {
       "version": "1.0.1",
@@ -19940,14 +19940,6 @@
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
     },
-    "short-hash": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/short-hash/-/short-hash-1.0.0.tgz",
-      "integrity": "sha1-P0kdco/Md37GBbuvf4PyNxL0IFA=",
-      "requires": {
-        "hash-string": "^1.0.0"
-      }
-    },
     "side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -21535,6 +21527,14 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
+    },
+    "xxhashjs": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/xxhashjs/-/xxhashjs-0.2.2.tgz",
+      "integrity": "sha512-AkTuIuVTET12tpsVIQo+ZU6f/qDmKuRUcjaqR+OIvm+aCBsZ95i7UVY5WJ9TMsSaZ0DA2WxoZ4acu0sPH+OKAw==",
+      "requires": {
+        "cuint": "^0.2.2"
+      }
     },
     "y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -53,11 +53,11 @@
     "protocol-buffers-encodings": "^1.1.1",
     "record-cache": "^1.1.1",
     "scramjet": "^4.36.1",
-    "short-hash": "^1.0.0",
     "snappyjs": "^0.6.1",
     "stream-chain": "^2.2.4",
     "stream-json": "^1.7.3",
     "ws": "^8.4.0",
+    "xxhashjs": "^0.2.2",
     "yaml": "^1.10.2"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/lmangani/cLoki/issues/113

Changes:

* Replace `short-hash` library with `xxhashjs` library. Should result in superior collision resistance. 
* There might be some other options, I have not evaluated them. Selected this library because I know it works well and because js port exists
* There is also this port: https://www.npmjs.com/package/xxhash-addon/v/1.4.0
    - it looks like it might be faster, but it requires compiling some native stuff. wdyt?
* No idea what happens during migration. Looks to me it might just work (while maybe generating a number of other collisions). wdyt?