### PR TITLE
To fix a missing modules error on install

### DIFF
--- a/lib/handlers/errors.js
+++ b/lib/handlers/errors.js
@@ -1,5 +1,3 @@
-const { logger } = require('logfmt/lib/request_logger')
-
 class CLokiError extends Error {
   constructor (code, name, message) {
     super(message)


### PR DESCRIPTION
This is requiring a logger we do not have in dependency. But logger is not used in this instance, so the line can be removed.