### PR TITLE
Elastic Ingestion APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,13 @@
 
 ### like Loki, but for ClickHouse
 
-**cLoki** is a flexible [Loki](https://github.com/grafana/loki) [^1] & [Tempo](https://github.com/grafana/tempo) [^1] compatible **LogQL API** built on top of [ClickHouse](https://clickhouse.com/)<br/>
-- Built in [Explore UI](https://github.com/metrico/cloki-view) and [LogQL CLI](https://github.com/lmangani/vLogQL) for querying data
-- Native support [Grafana](http://docs.grafana.org/features/explore/) [^3] and any [LogQL](https://grafana.com/docs/loki/latest/logql/) clients for [querying](https://github.com/lmangani/cLoki/wiki/LogQL-for-Beginners), [processing](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries), [ingesting](https://github.com/lmangani/cLoki/wiki/Inserting-Logs-to-cLoki), [tracing](https://github.com/lmangani/cLoki/wiki/Tempo-Tracing) and [alerting](https://github.com/lmangani/cLoki/wiki/Ruler---Alerts) [^2] 
+**cLoki** is a flexible [Loki](https://github.com/grafana/loki) [^1] compatible **LogQL API** built on top of [ClickHouse](https://clickhouse.com/)<br/>
+- Built in [Explore UI](https://github.com/metrico/cloki-view) and [LogQL CLI](https://github.com/lmangani/vLogQL) for querying and extracting data
+- Native support for [Grafana](http://docs.grafana.org/features/explore/) [^3] and any [LogQL](https://grafana.com/docs/loki/latest/logql/) clients for [querying](https://github.com/lmangani/cLoki/wiki/LogQL-for-Beginners), [processing](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries), [ingesting](https://github.com/lmangani/cLoki/wiki/Inserting-Logs-to-cLoki), [tracing](https://github.com/lmangani/cLoki/wiki/Tempo-Tracing) and [alerting](https://github.com/lmangani/cLoki/wiki/Ruler---Alerts) [^2] 
+- Powerful pipeline parsers to dynamically search, filter and extract values or tags from logs, events, traces _and beyond_
+- Ingestion and PUSH APIs transparently compatible with LogQL, PromQL, InfluxDB, Elastic _and more_
+- Natively support in Agents such as Promtail, Grafana-Agent, Vector, Logstash, Telegraf and _many others_
+- Cloud native, stateless and compact design
 <br>
 
 :octocat: Get started using the [cLoki Wiki](https://github.com/lmangani/cLoki/wiki) :bulb: 

--- a/cloki.js
+++ b/cloki.js
@@ -305,6 +305,13 @@ fastify.get('/ready', handlerHello)
 const handlerPush = require('./lib/handlers/push.js').bind(this)
 fastify.post('/loki/api/v1/push', handlerPush)
 
+/* Elastic Write Handler */
+const handlerElasticPush = require('./lib/handlers/elastic_index.js').bind(this)
+fastify.post('/:target/_doc', handlerElasticPush)
+fastify.post('/:target/_create/:id', handlerElasticPush)
+fastify.put('/:target/_doc/:id', handlerElasticPush)
+fastify.put('/:target/_create/:id', handlerElasticPush)
+
 /* Tempo Write Handler */
 this.tempo_tagtrace = process.env.TEMPO_TAGTRACE || false
 const handlerTempoPush = require('./lib/handlers/tempo_push.js').bind(this)

--- a/cloki.js
+++ b/cloki.js
@@ -311,6 +311,9 @@ fastify.post('/:target/_doc', handlerElasticPush)
 fastify.post('/:target/_create/:id', handlerElasticPush)
 fastify.put('/:target/_doc/:id', handlerElasticPush)
 fastify.put('/:target/_create/:id', handlerElasticPush)
+const handlerElasticBulk = require('./lib/handlers/elastic_bulk.js').bind(this)
+fastify.post('/_bulk', handlerElasticBulk)
+fastify.post('/:target/_bulk', handlerElasticBulk)
 
 /* Tempo Write Handler */
 this.tempo_tagtrace = process.env.TEMPO_TAGTRACE || false

--- a/cloki.js
+++ b/cloki.js
@@ -141,6 +141,10 @@ async function genericJSONOrYAMLParser (req) {
     }
     await shaper.register(length)
     const body = await getContentBody(req)
+    if (req.routerPath === '/_bulk') {
+      // ndjson bypass
+      return body
+    }
     try { return JSON.parse(body) } catch (e) {}
     try { return yaml.parse(body) } catch (e) {}
     throw new Error('Unexpected request content-type')

--- a/cloki.js
+++ b/cloki.js
@@ -141,10 +141,6 @@ async function genericJSONOrYAMLParser (req) {
     }
     await shaper.register(length)
     const body = await getContentBody(req)
-    if (req.routerPath === '/_bulk') {
-      // ndjson bypass
-      return body
-    }
     try { return JSON.parse(body) } catch (e) {}
     try { return yaml.parse(body) } catch (e) {}
     throw new Error('Unexpected request content-type')
@@ -285,6 +281,11 @@ try {
 }
 
 fastify.addContentTypeParser('application/json', {},
+  async function (req, body, done) {
+    return await genericJSONParser(req)
+  })
+
+fastify.addContentTypeParser('application/x-ndjson', {},
   async function (req, body, done) {
     return await genericJSONParser(req)
   })

--- a/lib/handlers/elastic_bulk.js
+++ b/lib/handlers/elastic_bulk.js
@@ -1,4 +1,3 @@
-
 /* Elastic Indexing Handler
     Accepts JSON formatted requests when the header Content-Type: application/json is sent.
 
@@ -12,8 +11,8 @@ const stringify = require('json-stable-stringify')
 function handler (req, res) {
   const self = this
   req.log.debug('ELASTIC Bulk Request')
-  if (!req.body || !req.params.target) {
-    req.log.error('No Request Body or Target!')
+  if (!req.body) {
+    req.log.error('No Request Body or Target!'+ req.body)
     res.code(500).send()
     return
   }
@@ -31,31 +30,28 @@ function handler (req, res) {
                 req.headers['content-type'].indexOf('application/x-ndjson') > -1
   ) {
     // ndjson body
-    streams = req.body.split(/\r?\n/)
+    streams = req.body.split(/\n/)
   } else {
     // assume ndjson raw body
-    streams = req.body.split(/\r?\n/)
+    streams = req.body.split(/\n/)
   }
   req.log.debug({ streams}, streams.lenght + ' bulk streams')
-  req.log.debug({ streams }, 'streams')
   var last_tags = false;
   if (streams) {
     streams.forEach(function (stream) {
-      req.log.debug({ stream }, 'ingesting elastic bulk row')
-
       try {
-        stream = JSON.parse(JSON.stringify(stream))
+        stream = JSON.parse(stream)
       } catch (err) { req.log.error({ err }); return };
 
       // Allow Index, Create. Discard Delete, Update.
-      if (index.delete||index.update) { last_tags = false; return; }
+      if (stream.delete||stream.update) { last_tags = false; return; }
       var command = stream.index || stream.create || false;
       if (command && !last_tags) {
-	last_tags=stream.index;
-	return;
+	      last_tags=stream.index;
+	      return;
       }
 
-      // Data Row
+      // Data Rows
       let finger = null
       let JSONLabels = last_tags;
       try {

--- a/lib/handlers/elastic_bulk.js
+++ b/lib/handlers/elastic_bulk.js
@@ -61,7 +61,7 @@ function handler (req, res) {
       try {
         try {
           JSONLabels.type = 'elastic'
-          if (doc_target) JSONLabels.target = doc_target
+          if (doc_target) JSONLabels._index = doc_target
           JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
         } catch (err) {
           req.log.error({ err })

--- a/lib/handlers/elastic_bulk.js
+++ b/lib/handlers/elastic_bulk.js
@@ -2,10 +2,8 @@
 /* Elastic Indexing Handler
     Accepts JSON formatted requests when the header Content-Type: application/json is sent.
 
-	POST /<target>/_doc/
-	PUT /<target>/_doc/<_id>
-	PUT /<target>/_create/<_id>
-	POST /<target>/_create/<_id>
+	POST /_bulk
+	POST /<target>/_bulk
 
 */
 
@@ -13,7 +11,7 @@ const stringify = require('json-stable-stringify')
 
 function handler (req, res) {
   const self = this
-  req.log.debug('ELASTIC Index Request')
+  req.log.debug('ELASTIC Bulk Request')
   if (!req.body || !req.params.target) {
     req.log.error('No Request Body or Target!')
     res.code(500).send()
@@ -26,30 +24,44 @@ function handler (req, res) {
   }
 
   const doc_target = req.params.target || false;
-  const doc_id = req.params.id || false;
 
   let streams
   if (
     req.headers['content-type'] &&
-                req.headers['content-type'].indexOf('application/json') > -1
+                req.headers['content-type'].indexOf('application/x-ndjson') > -1
   ) {
-    // json body, do we need to split?
+    // ndjson body
     streams = req.body.split(/\r?\n/)
   } else {
-    // raw body
+    // assume ndjson raw body
     streams = req.body.split(/\r?\n/)
   }
-  req.log.info({ streams }, 'streams')
+  req.log.debug({ streams}, streams.lenght + ' bulk streams')
+  req.log.debug({ streams }, 'streams')
+  var last_tags = false;
   if (streams) {
     streams.forEach(function (stream) {
-      req.log.debug({ stream }, 'ingesting elastic doc')
+      req.log.debug({ stream }, 'ingesting elastic bulk row')
+
+      try {
+        stream = JSON.parse(JSON.stringify(stream))
+      } catch (err) { req.log.error({ err }); return };
+
+      // Allow Index, Create. Discard Delete, Update.
+      if (index.delete||index.update) { last_tags = false; return; }
+      var command = stream.index || stream.create || false;
+      if (command && !last_tags) {
+	last_tags=stream.index;
+	return;
+      }
+
+      // Data Row
       let finger = null
-      let JSONLabels = {}
+      let JSONLabels = last_tags;
       try {
         try {
           JSONLabels.type = 'elastic'
           if (doc_target) JSONLabels.target = doc_target
-          if (doc_id) JSONLabels.id = doc_id
           JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
         } catch (err) {
           req.log.error({ err })
@@ -75,9 +87,6 @@ function handler (req, res) {
         req.log.error({ err }, 'failed ingesting elastic doc')
       }
 
-      try {
-        stream = JSON.parse(JSON.stringify(stream))
-      } catch (err) { req.log.error({ err }); return };
       // Store Elastic Doc Object
       const values = [
         finger,
@@ -87,6 +96,9 @@ function handler (req, res) {
       ]
       req.log.debug({ finger, values }, 'store')
       self.bulk.add([values])
+
+      // Reset State, Expect Command
+      last_tags = false;
     })
   }
   res.code(200).send()

--- a/lib/handlers/elastic_bulk.js
+++ b/lib/handlers/elastic_bulk.js
@@ -13,12 +13,12 @@ function handler (req, res) {
   req.log.debug('ELASTIC Bulk Request')
   if (!req.body) {
     req.log.error('No Request Body or Target!'+ req.body)
-    res.code(500).send()
+    res.code(400).send('{"status":400, "error": { "reason": "No Request Body" } }')
     return
   }
   if (this.readonly) {
     req.log.error('Readonly! No push support.')
-    res.code(500).send()
+    res.code(400).send('{"status":400, "error": { "reason": "Read Only Mode" } }')
     return
   }
 
@@ -97,7 +97,7 @@ function handler (req, res) {
       last_tags = false;
     })
   }
-  res.code(200).send()
+  res.code(200).send('{"took":0, "errors": false }')
 }
 
 module.exports = handler

--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -16,12 +16,12 @@ function handler (req, res) {
   req.log.debug('ELASTIC Index Request')
   if (!req.body || !req.params.target) {
     req.log.error('No Request Body or Target!')
-    res.code(500).send()
+    res.code(400).send('{"status":400, "error": { "reason": "No Request Body" } }')
     return
   }
   if (this.readonly) {
     req.log.error('Readonly! No push support.')
-    res.code(500).send()
+    res.code(400).send('{"status":400, "error": { "reason": "Read Only Mode" } }')
     return
   }
 
@@ -88,7 +88,7 @@ function handler (req, res) {
       self.bulk.add([values])
     })
   }
-  res.code(200).send()
+  res.code(200).send('{"took":0, "errors": false }')
 }
 
 module.exports = handler

--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -33,11 +33,11 @@ function handler (req, res) {
     req.headers['content-type'] &&
                 req.headers['content-type'].indexOf('application/json') > -1
   ) {
-    // raw body, handle as ndjson
+    // json body, handle as sinle node array
     streams = [req.body]
   } else {
-    // raw body
-    streams = req.body.split(/\r?\n/)
+    // raw body, handle as ndjson
+    streams = req.body.split(/\n/)
   }
   req.log.info({ streams }, 'streams')
   if (streams) {
@@ -58,7 +58,6 @@ function handler (req, res) {
         // Calculate Fingerprint
         const strJson = stringify(JSONLabels)
         finger = self.fingerPrint(strJson)
-        req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
         // Store Fingerprint
         self.bulk_labels.add([[
           new Date().toISOString().split('T')[0],

--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -33,8 +33,8 @@ function handler (req, res) {
     req.headers['content-type'] &&
                 req.headers['content-type'].indexOf('application/json') > -1
   ) {
-    // json body, do we need to split?
-    streams = req.body.split(/\r?\n/)
+    // raw body, handle as ndjson
+    streams = [req.body]
   } else {
     // raw body
     streams = req.body.split(/\r?\n/)

--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -1,0 +1,95 @@
+
+/* Elastic Indexing Handler
+    Accepts JSON formatted requests when the header Content-Type: application/json is sent.
+
+	POST /<target>/_doc/
+	PUT /<target>/_doc/<_id>
+	PUT /<target>/_create/<_id>
+	POST /<target>/_create/<_id>
+
+*/
+
+const stringify = require('json-stable-stringify')
+
+function handler (req, res) {
+  const self = this
+  req.log.debug('ELASTIC Index Request')
+  if (!req.body || !req.params.target) {
+    req.log.error('No Request Body or Target!')
+    res.code(500).send()
+    return
+  }
+  if (this.readonly) {
+    req.log.error('Readonly! No push support.')
+    res.code(500).send()
+    return
+  }
+
+  const doc_target = req.params.target || false;
+  const doc_id = req.params.id || false;
+
+  let streams
+  if (
+    req.headers['content-type'] &&
+                req.headers['content-type'].indexOf('application/json') > -1
+  ) {
+    // json body, do we need to split?
+    streams = req.body.split(/\r?\n/)
+  } else {
+    // raw body
+    streams = req.body.split(/\r?\n/)
+  }
+  req.log.info({ streams }, 'streams')
+  if (streams) {
+    streams.forEach(function (stream) {
+      req.log.debug({ stream }, 'ingesting elastic doc')
+      let finger = null
+      let JSONLabels = {}
+      try {
+        try {
+          JSONLabels.type = 'elastic'
+          if (doc_target) JSONLabels.target = doc_target
+          if (doc_target) JSONLabels.id = doc_id
+          JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
+        } catch (err) {
+          req.log.error({ err })
+          return
+        }
+        // Calculate Fingerprint
+        const strJson = stringify(JSONLabels)
+        finger = self.fingerPrint(strJson)
+        req.log.debug({ JSONLabels, finger }, 'LABELS FINGERPRINT')
+        // Store Fingerprint
+        self.bulk_labels.add([[
+          new Date().toISOString().split('T')[0],
+          finger,
+          strJson,
+          JSONLabels.target || ''
+        ]])
+        for (const key in JSONLabels) {
+          req.log.debug({ key, data: JSONLabels[key] }, 'Storing label')
+          self.labels.add('_LABELS_', key)
+          self.labels.add(key, JSONLabels[key])
+        }
+      } catch (err) {
+        req.log.error({ err }, 'failed ingesting elastic doc')
+      }
+
+      try {
+        stream = JSON.parse(JSON.stringify(stream))
+      } catch (err) { req.log.error({ err }); return };
+      // Store Tempo Object
+      const values = [
+        finger,
+        BigInt((new Date().getTime() * 1000) + '000'),
+        null,
+        JSON.stringify(doc) || stream
+      ]
+      req.log.debug({ finger, values }, 'store')
+      self.bulk.add([values])
+    })
+  }
+  res.code(200).send()
+}
+
+module.exports = handler

--- a/lib/handlers/elastic_index.js
+++ b/lib/handlers/elastic_index.js
@@ -48,8 +48,8 @@ function handler (req, res) {
       try {
         try {
           JSONLabels.type = 'elastic'
-          if (doc_target) JSONLabels.target = doc_target
-          if (doc_id) JSONLabels.id = doc_id
+          if (doc_target) JSONLabels._index = doc_target
+          if (doc_id) JSONLabels._id = doc_id
           JSONLabels = Object.fromEntries(Object.entries(JSONLabels).sort())
         } catch (err) {
           req.log.error({ err })


### PR DESCRIPTION
## cLoki Elastic Push 
This (untested) PR implements extremely basic support for ingesting logs emulating the Elastic `index` and `bulk` APIs 

- [x] index API emulation
- [x] bulk API emulation
- [x] response emulation 
- [ ] test scenario

### Endpoints
```
fastify.post('/:target/_doc', handlerElasticPush)
fastify.post('/:target/_create/:id', handlerElasticPush)
fastify.put('/:target/_doc/:id', handlerElasticPush)
fastify.put('/:target/_create/:id', handlerElasticPush)
fastify.post('/_bulk', handlerElasticBulk)
fastify.post('/:target/_bulk', handlerElasticBulk)
```

### Push Handlers
The `target` and `id` tags are automatically added to each insert from `index` and `bulk` API requests

#### Index API
```
# curl -X POST "localhost:3100/my-index-000001/_doc" -H 'Content-Type: application/json' -d'
{
  "message": "hello",
  "user": "cloki"
}
'
```
#### Bulk API
```
# cat bulkreq
{ "index" : { "_index" : "test-index", "_id" : "1234" } }
{ "message" : "hello", "user": "cloki" }

# curl -s -H "Content-Type: application/x-ndjson" -XPOST http://localhost/_bulk --data-binary "@bulkreq"
```


Either type of insert will be equivalent to the following logQL/cLoki push:

```
{
      "stream": {
        "_index": "test-index",
        "_id": "1234",
        "type": "elastic"
      },
      "values": [
          [ "<unix epoch in nanoseconds>", "{\"message\": \"hello\", \"user\":\"cloki'"}" ]
      ]
    }
```

### Notes
- The implementation is not focused on speed. Bulking capacity depends on fastify settings.
- A static `type` tag is also attached to events ingested through the `elastic` compatible APIs
- delete, update bulk actions are not supported
