### PR TITLE
RENAME/MIGRATION

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -90,3 +90,5 @@ jobs:
           tags: |
             qxip/qryn:latest
             qxip/qryn:${{ steps.version-bump.outputs.newTag }}
+            qxip/cloki:latest
+            qxip/cloki:${{ steps.version-bump.outputs.newTag }}

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -88,5 +88,5 @@ jobs:
         with:
           push: true
           tags: |
-            qxip/cloki:latest
-            qxip/cloki:${{ steps.version-bump.outputs.newTag }}
+            qxip/qryn:latest
+            qxip/qryn:${{ steps.version-bump.outputs.newTag }}

--- a/.github/workflows/node-clickhouse.js.yml
+++ b/.github/workflows/node-clickhouse.js.yml
@@ -34,4 +34,4 @@ jobs:
         CLICKHOUSE_DB: loki
         CLICKHOUSE_TSDB: loki
         INTEGRATION_E2E: 1
-      run: node cloki.js & npm run test --forceExit
+      run: node qryn.js & npm run test --forceExit

--- a/.github/workflows/npm-clickhouse.yml
+++ b/.github/workflows/npm-clickhouse.yml
@@ -24,10 +24,10 @@ jobs:
       uses: actions/setup-node@v2
       with:
         node-version: ${{ matrix.node-version }}
-    - run: npm install --unsafe-perm -g cloki
+    - run: npm install --unsafe-perm -g qryn
     - env:
         CLICKHOUSE_DB: loki
         DEBUG: true
-      run: cd $(dirname $(readlink -f `which cloki`)) && (timeout 10s cloki || ( [[ $? -eq 124 ]] && exit 0 ))
+      run: cd $(dirname $(readlink -f `which qryn`)) && (timeout 10s qryn || ( [[ $? -eq 124 ]] && exit 0 ))
 #   - run: npm install -g jest
-#   - run: cd $(dirname $(readlink -f `which cloki`)) && npm run test
+#   - run: cd $(dirname $(readlink -f `which qryn`)) && npm run test

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 # qryn 
 
-### It's LogQL for Uptrace
+### LogQL for ClickHouse
 
 **qryn** is a flexible **LogQL API** built on top of [ClickHouse](https://clickhouse.com/) and natively integrated in [Uptrace](https://uptrace.dev)<br/>
 - Built in [Explore UI](https://github.com/metrico/cloki-view) and [LogQL CLI](https://github.com/lmangani/vLogQL) for querying and extracting data

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The following ENV Variables can be used to control qryn parameters and backend s
 #### Contributors
 
 <a href="https://github.com/lmangani/qryn/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=lmangani/qryn" />
+  <img src="https://contributors-img.web.app/image?repo=lmangani/cloki" />
 </a>
 
 #### Disclaimer

--- a/README.md
+++ b/README.md
@@ -1,22 +1,23 @@
-<img src='https://user-images.githubusercontent.com/1423657/147935343-598c7dfd-1412-4bad-9ac6-636994810443.png' style="margin-left:-10px" width=220>
+<img src='https://user-images.githubusercontent.com/1423657/173144443-fc7ba783-d5bf-47f9-bf59-707693da5ed1.png' style="margin-left:-10px" width=120/><img src="https://user-images.githubusercontent.com/1423657/173145328-dc9cc3b0-85fc-49d9-8e8a-5128a363408f.png" width=400/>
+
 
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/lmangani/lmangani%2FcLoki%2FcLoki?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NTkxMzIxNGZlNjQxOWIwMDA2OWY1ZjU4.s1Y7vvE73ZWAIGYb4YCkATleW61RZ8sKypOc8Vae1c0&type=cf-1)]( https://g.codefresh.io/pipelines/cLoki/builds?repoOwner=lmangani&repoName=cLoki&serviceName=lmangani%2FcLoki&filter=trigger:build~Build;branch:master;pipeline:5cdf4a833a13130275ac87a8~cLoki)
 ![CodeQL](https://github.com/lmangani/cLoki/workflows/CodeQL/badge.svg)
 
-# cLoki
+# qryn 
 
-### like Loki, but for ClickHouse
+### It's LogQL for Uptrace
 
-**cLoki** is a flexible [Loki](https://github.com/grafana/loki) [^1] compatible **LogQL API** built on top of [ClickHouse](https://clickhouse.com/)<br/>
+**qryn** is a flexible **LogQL API** built on top of [ClickHouse](https://clickhouse.com/) and natively integrated in [Uptrace](https://uptrace.dev)<br/>
 - Built in [Explore UI](https://github.com/metrico/cloki-view) and [LogQL CLI](https://github.com/lmangani/vLogQL) for querying and extracting data
-- Native [Grafana](http://docs.grafana.org/features/explore/) [^3] and [LogQL](https://grafana.com/docs/loki/latest/logql/) APIs for [querying](https://github.com/lmangani/cLoki/wiki/LogQL-for-Beginners), [processing](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries), [ingesting](https://github.com/lmangani/cLoki/wiki/Inserting-Logs-to-cLoki), [tracing](https://github.com/lmangani/cLoki/wiki/Tempo-Tracing) and [alerting](https://github.com/lmangani/cLoki/wiki/Ruler---Alerts) [^2] 
+- Native [Grafana](http://docs.grafana.org/features/explore/) [^3] and [LogQL](https://grafana.com/docs/loki/latest/logql/) APIs for [querying](https://github.com/lmangani/qryn/wiki/LogQL-for-Beginners), [processing](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries), [ingesting](https://github.com/lmangani/qryn/wiki/Inserting-Logs-to-cLoki), [tracing](https://github.com/lmangani/qryn/wiki/Tempo-Tracing) and [alerting](https://github.com/lmangani/qryn/wiki/Ruler---Alerts) [^2] 
 - Powerful pipeline to dynamically search, filter and extract data from logs, events, traces _and beyond_
 - Ingestion and PUSH APIs transparently compatible with LogQL, PromQL, InfluxDB, Elastic _and more_
 - Ready to use with Agents such as Promtail, Grafana-Agent, Vector, Logstash, Telegraf and _many others_
 - Cloud native, stateless and compact design
 <br>
 
-:octocat: Get started using the [cLoki Wiki](https://github.com/lmangani/cLoki/wiki) :bulb: 
+:octocat: Get started using our [Wiki](https://github.com/lmangani/qryn/wiki) :bulb: 
 
 
 ![ezgif com-optimize 15](https://user-images.githubusercontent.com/1423657/50496835-404e6480-0a33-11e9-87a4-aebb71a668a7.gif)
@@ -24,51 +25,49 @@
 
 ### Project Background
 
-The *Loki API* and its Grafana native integration are brilliant, simple and appealing - but we just love **ClickHouse**. 
-
-**cLoki** implements a complete LogQL API buffered by a fast bulking **LRU** sitting on top of **ClickHouse** tables and relying on its *columnar search and insert performance alongside solid distribution and clustering capabilities* for stored data. Just like Loki, cLoki does not parse or index incoming logs, but rather groups log streams using the same label system as Prometheus. [^2]
+**qryn** implements a complete LogQL API buffered by a fast bulking **LRU** sitting on top of **ClickHouse** tables and relying on its *columnar search and insert performance alongside solid distribution and clustering capabilities* for stored data. qryn does not parse or index incoming logs, but rather groups log streams using the same label system as Prometheus. [^2]
 
 <img src="https://user-images.githubusercontent.com/1423657/54091852-5ce91000-4385-11e9-849d-998c1e5d3243.png" width=700 />
 
 ### :fire: LogQL: Supported Features
 
-cLoki implements a broad range of [LogQL Queries](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries) to provide transparent compatibility with the Loki API<br>
+qryn implements a broad range of [LogQL Queries](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries) to provide transparent compatibility with the Loki API<br>
 The Grafana Loki datasource can be used to natively query _logs_ and display extracted _timeseries_<br>
 
 :tada: _No plugins needed_ 
 
 <img src="https://user-images.githubusercontent.com/1423657/135249640-5f5a61e5-0f94-4517-b052-76d47c3572f5.png" height=100>
 
-- [Log Stream Selector](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#log-stream-selector)
-- [Line Filter Expression](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#line-filter-expression)
-- [Label Filter Expression](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#label-filter-expression)
-- [Parser Expression](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#parser-expression)
-- [Log Range Aggregations](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#log-range-aggregations)
-- [Aggregation operators](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#aggregation-operators)
-- [Unwrap Expression.](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#unwrap-expression)
-- [Line Format Expression](https://github.com/lmangani/cLoki/wiki/LogQL-Supported-Queries#line-format-expression---handlebars--)
+- [Log Stream Selector](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#log-stream-selector)
+- [Line Filter Expression](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#line-filter-expression)
+- [Label Filter Expression](https://github.com/lmangani/cLqrynoki/wiki/LogQL-Supported-Queries#label-filter-expression)
+- [Parser Expression](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#parser-expression)
+- [Log Range Aggregations](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#log-range-aggregations)
+- [Aggregation operators](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#aggregation-operators)
+- [Unwrap Expression.](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#unwrap-expression)
+- [Line Format Expression](https://github.com/lmangani/qryn/wiki/LogQL-Supported-Queries#line-format-expression---handlebars--)
 
-:fire: Follow our [examples](https://github.com/lmangani/cLoki/wiki/LogQL-for-Beginners) to get started
+:fire: Follow our [examples](https://github.com/lmangani/qryn/wiki/LogQL-for-Beginners) to get started
 
 --------
 
 ### :fuelpump: Log Streams
 
-cLoki supports input via Push API using *JSON* or *Protobuf* and it is compatible with [Promtail](https://grafana.com/docs/loki/latest/clients/promtail/) and any other [Loki compatible agent](https://github.com/lmangani/cLoki/wiki/Inserting-Logs-to-cLoki). On top of that, cLoki also accepts and converts log and metric inserts using Influx, Elastic, Tempo and other common API formats.
+qryn supports input via Push API using *JSON* or *Protobuf* and it is compatible with [Promtail](https://grafana.com/docs/loki/latest/clients/promtail/) and any other [LogQL compatible agent](https://github.com/lmangani/qryn/wiki/Inserting-Logs-to-cLoki). On top of that, qryn also accepts and converts log and metric inserts using Influx, Elastic, Tempo and other common API formats.
 
-Our _preferred_ companion for parsing and shipping log streams to **cLoki** is [paStash](https://github.com/sipcapture/paStash/wiki/Example:-Loki) with extensive interpolation capabilities to create tags and trim any log fat. Sending JSON formatted logs is _suggested_ when dealing with metrics.
+Our _preferred_ companion for parsing and shipping log streams to **qryn** is [paStash](https://github.com/sipcapture/paStash/wiki/Example:-Loki) with extensive interpolation capabilities to create tags and trim any log fat. Sending JSON formatted logs is _suggested_ when dealing with metrics.
 
 --------
 
 ### :fire: CliQL: Experimental 2.0 Features
 
-cLoki implements custom query functions for ClickHouse timeseries extraction, allowing direct access to any existing table
+qryn implements custom query functions for ClickHouse timeseries extraction, allowing direct access to any existing table
 
 ![ezgif com-gif-maker](https://user-images.githubusercontent.com/1423657/99530591-d0885080-29a1-11eb-87e6-870a046fb4de.gif)
 
 
 #### Timeseries
-Convert columns to tagged timeseries using the emulated loki 2.0 query format
+Convert columns to tagged timeseries using the emulated LogQL 2.0 query format
 ```
 <aggr-op> by (<labels,>) (<function>(<metric>[range_in_seconds])) from <database>.<table> where <optional condition>
 ```
@@ -107,64 +106,50 @@ clickhouse({
 |timefield| time/date field name (optional) |
 
 
---------
-
-### :fire: Tempo: Supported Features
-
-**cLoki Pulse** offers experimental support for the Grafana [Tempo API](https://github.com/lmangani/cLoki/wiki/Tempo-Tracing) providing span ingestion and querying
-
-At database level, Tempo Spans/Traces are stored as tagged Logs and are accessible from both LogQL and Tempo APIs
-
-<img src="https://user-images.githubusercontent.com/1423657/147878090-a7630467-433e-4912-a439-602ce719c21d.png" width=700 />
-
-------------
-
-
-
 
 ### Setup
 
-Check out the [Wiki](https://github.com/lmangani/cLoki/wiki) for detailed instructions or choose a quick method:
+Check out the [Wiki](https://github.com/lmangani/qryn/wiki) for detailed instructions or choose a quick method:
 
 ##### :busstop: GIT (Manual)
 Clone this repository, install with `npm`and run using `nodejs` 14.x *(or higher)*
 ```bash
 npm install
-CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="cloki" node cloki.js
+CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="qryn" node qryn.js
 ```
 ##### :busstop: NPM
-Install `cloki` as global package on your system using `npm`
+Install `qryn` as global package on your system using `npm`
 ```bash
-sudo npm install -g cloki
-cd $(dirname $(readlink -f `which cloki`)) \
-  && CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="cloki" cloki
+sudo npm install -g qryn
+cd $(dirname $(readlink -f `which qryn`)) \
+  && CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="qryn" qryn
 ```
 ##### :busstop: PM2
 ```bash
-sudo npm install -g cloki pm2
-cd $(dirname $(readlink -f `which cloki`)) \
-  && CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="cloki" pm2 start cloki
+sudo npm install -g qryn pm2
+cd $(dirname $(readlink -f `which qryn`)) \
+  && CLICKHOUSE_SERVER="my.clickhouse.server" CLICKHOUSE_AUTH="default:password" CLICKHOUSE_DB="qryn" pm2 start qryn
 pm2 save
 pm2 startup
 ```
 
 ##### :busstop: Docker
-For a fully working demo, check the [docker-compose](https://github.com/lmangani/cLoki/tree/master/docker) example
+For a fully working demo, check the [docker-compose](https://github.com/lmangani/qryn/tree/master/docker) example
 
 
 --------------
 
 #### Logging
-The project uses [pino](https://github.com/pinojs/pino) for logging and by default outputs JSON'ified log lines. If you want to see "pretty" log lines you can start cloki with `npm run pretty`
+The project uses [pino](https://github.com/pinojs/pino) for logging and by default outputs JSON'ified log lines. If you want to see "pretty" log lines you can start qryn with `npm run pretty`
 
 #### Configuration
-The following ENV Variables can be used to control cLoki parameters and backend settings.
+The following ENV Variables can be used to control qryn parameters and backend settings.
 
 |ENV   	|Default   	|Usage   	|
 |---	|---	    |---		|
 | CLICKHOUSE_SERVER | localhost   	| Clickhouse Server address  		|
 | CLICKHOUSE_PORT  	| 8123  	    | Clickhouse Server port  		|
-| CLICKHOUSE_DB  	| cloki  	    | Clickhouse Database Name  		|
+| CLICKHOUSE_DB  	| qryn  	    | Clickhouse Database Name  		|
 | CLICKHOUSE_AUTH  	| default:  	    | Clickhouse Authentication (user:password) |
 | CLICKHOUSE_PROTO  	| http  	    | Clickhouse Protocol (http, https) |
 | CLICKHOUSE_TIMEFIELD  | record_datetime    | Clickhouse DateTime column for native queries |
@@ -173,8 +158,8 @@ The following ENV Variables can be used to control cLoki parameters and backend 
 | BULK_MAXCACHE  	| 50000  	    | Max Labels in Memory Cache  		|
 | LABELS_DAYS  		| 7  	    	    | Max Days before Label rotation  		|
 | SAMPLES_DAYS  	| 7  	    	    | Max Days before Timeseries rotation  		|
-| HOST 			| 0.0.0.0 	    | cLOKi API IP  		|
-| PORT  		| 3100 	            | cLOKi API PORT  		|
+| HOST 			| 0.0.0.0 	    | HTTP API IP  		|
+| PORT  		| 3100 	            | HTTP API PORT  		|
 | CLOKI_LOGIN           | undefined             | Basic HTTP Username           |
 | CLOKI_PASSWORD        | undefined             | Basic HTTP Password           |
 | READONLY  			| false  	    | Readonly Mode, no DB Init  		|
@@ -192,16 +177,16 @@ The following ENV Variables can be used to control cLoki parameters and backend 
 
 #### Contributors
 
-<a href="https://github.com/lmangani/cloki/graphs/contributors">
-  <img src="https://contributors-img.web.app/image?repo=lmangani/cloki" />
+<a href="https://github.com/lmangani/qryn/graphs/contributors">
+  <img src="https://contributors-img.web.app/image?repo=lmangani/qryn" />
 </a>
 
 #### Disclaimer
 
 ©️ QXIP BV, released under the GNU Affero General Public License v3.0. See [LICENSE](LICENSE) for details.
 
-[^1]: cLoki is not affiliated or endorsed by Grafana Labs or ClickHouse Inc. All rights belong to their respective owners.
+[^1]: qryn is not affiliated or endorsed by Grafana Labs or ClickHouse Inc. All rights belong to their respective owners.
 
-[^2]: cLoki is a 100% clear-room api implementation and does not fork, use or derivate from Grafana Loki code or concepts.
+[^2]: qryn is a 100% clear-room api implementation and does not fork, use or derivate from Grafana Loki code or concepts.
 
 [^3]: Grafana®, Loki™ and Tempo® are a Trademark of Raintank, Grafana Labs. ClickHouse® is a trademark of ClickHouse Inc. Prometheus is a trademark of The Linux Foundation.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@
 
 :octocat: Get started using our [Wiki](https://github.com/lmangani/qryn/wiki) :bulb: 
 
+⚠️: Existing user and confused? The project has been renamed to `qryn` _(querying)_ 👍: 
+
 
 ![ezgif com-optimize 15](https://user-images.githubusercontent.com/1423657/50496835-404e6480-0a33-11e9-87a4-aebb71a668a7.gif)
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Codefresh build status]( https://g.codefresh.io/api/badges/pipeline/lmangani/lmangani%2FcLoki%2FcLoki?branch=master&key=eyJhbGciOiJIUzI1NiJ9.NTkxMzIxNGZlNjQxOWIwMDA2OWY1ZjU4.s1Y7vvE73ZWAIGYb4YCkATleW61RZ8sKypOc8Vae1c0&type=cf-1)]( https://g.codefresh.io/pipelines/cLoki/builds?repoOwner=lmangani&repoName=cLoki&serviceName=lmangani%2FcLoki&filter=trigger:build~Build;branch:master;pipeline:5cdf4a833a13130275ac87a8~cLoki)
 ![CodeQL](https://github.com/lmangani/cLoki/workflows/CodeQL/badge.svg)
 
-# qryn 
+# qryn / cLogQL
 
 ### LogQL for ClickHouse
 

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "cloki",
-  "version": "2.0.31",
+  "name": "qryn",
+  "version": "2.1.0",
   "description": "LogQL API with Clickhouse Backend",
-  "main": "cloki.js",
+  "main": "qryn.js",
   "bin": {
     "cloki": "./cloki.js"
   },
   "scripts": {
     "test": "jest",
-    "start": "node cloki.js",
-    "pretty": "node cloki.js | pino-pretty",
+    "start": "node qryn.js",
+    "pretty": "node qryn.js | pino-pretty",
     "postinstall": "patch-package",
     "install-view": "mkdir -p view && curl -L https://github.com/metrico/cloki-view/releases/latest/download/dist.zip | busybox unzip - -d ./view",
     "lint": "npx eslint --fix *.js lib parser plugins test"
@@ -21,14 +21,14 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+ssh://git@github.com/lmangani/cloki.git"
+    "url": "git+ssh://git@github.com/lmangani/qryn.git"
   },
   "author": "lorenzo.mangani@gmail.com",
   "license": "AGPL-3.0",
   "bugs": {
-    "url": "https://github.com/lmangani/cloki/issues"
+    "url": "https://github.com/lmangani/qryn/issues"
   },
-  "homepage": "https://github.com/lmangani/cloki#readme",
+  "homepage": "https://github.com/lmangani/qryn#readme",
   "dependencies": {
     "@apla/clickhouse": "^1.6.4",
     "@cloki/clickhouse-sql": "1.2.2",
@@ -80,7 +80,6 @@
     "lib": "lib"
   },
   "keywords": [
-    "loki",
     "logs",
     "logging",
     "logql",

--- a/pm2.ecosystem.js
+++ b/pm2.ecosystem.js
@@ -1,7 +1,7 @@
 module.exports = {
   apps: [{
-    name: 'cloki',
-    script: './cloki.js',
+    name: 'qryn',
+    script: './qryn.js',
     env: {
       CLICKHOUSE_SERVER: 'localhost',
       CLICKHOUSE_PORT: 8123,

--- a/qryn.js
+++ b/qryn.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 /*
- * Loki API to Clickhouse Gateway
+ * LogQL API to Clickhouse Gateway
  * (C) 2018-2022 QXIP BV
  */
 


### PR DESCRIPTION
Time has come! The project is now part of uptrace and things will change a bit.
 
Unfortunately, the old project name cannot be mentioned not to anger the gods of trademarks. So long cL**i

The new component name is `qryn` to be later consolidated into `uptrace-logql`